### PR TITLE
refactor: remove non-functional refresh button from project pages

### DIFF
--- a/src/app/projects/cac-unit-economics/components/NarrativeSections.tsx
+++ b/src/app/projects/cac-unit-economics/components/NarrativeSections.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { SectionCard } from '@/components/ui/section-card'
-import { ResultCard, TechGrid, FeatureCard } from '@/components/projects/shared'
-import { technologies } from '../data/constants'
+import { ResultCard, FeatureCard } from '@/components/projects/shared'
 
 export function NarrativeSections() {
   return (
@@ -189,9 +188,6 @@ export function NarrativeSections() {
           </p>
         </div>
       </SectionCard>
-
-      {/* Technologies Used */}
-      <TechGrid technologies={technologies} />
     </div>
   )
 }

--- a/src/app/projects/cac-unit-economics/page.tsx
+++ b/src/app/projects/cac-unit-economics/page.tsx
@@ -4,10 +4,8 @@ import { TrendingUp, DollarSign, Target, Calculator } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 
 import { ProjectPageLayout } from '@/components/projects/project-page-layout'
-import { LoadingState } from '@/components/projects/loading-state'
 import { MetricsGrid } from '@/components/projects/metrics-grid'
 import { SectionCard } from '@/components/ui/section-card'
-import { useLoadingState } from '@/hooks/use-loading-state'
 import { cacMetrics } from './data/constants'
 import { formatCurrency } from '@/lib/utils/data-formatters'
 import { OverviewTab } from './components/OverviewTab'
@@ -20,7 +18,6 @@ const tabs = ['overview', 'channels', 'products'] as const
 type Tab = (typeof tabs)[number]
 
 export default function CACUnitEconomics() {
-  const { isLoading, handleRefresh } = useLoadingState()
   const [activeTab, setActiveTab] = useQueryState('tab', { defaultValue: 'overview' as Tab })
 
   // Standardized metrics configuration using consistent data formatting
@@ -69,19 +66,13 @@ export default function CACUnitEconomics() {
         { label: 'ROI Optimization', variant: 'primary' },
         { label: 'Unit Economics', variant: 'secondary' },
       ]}
-      onRefresh={handleRefresh}
-      refreshButtonDisabled={isLoading}
       showTimeframes={true}
       timeframes={tabs.map((t) => t.charAt(0).toUpperCase() + t.slice(1))}
       activeTimeframe={activeTab.charAt(0).toUpperCase() + activeTab.slice(1)}
       onTimeframeChange={(timeframe) => setActiveTab(timeframe.toLowerCase() as Tab)}
     >
-      {isLoading ? (
-        <LoadingState />
-      ) : (
-        <>
-          {/* Key Metrics using standardized MetricsGrid */}
-          <MetricsGrid metrics={metrics} columns={4} loading={isLoading} className="mb-8" />
+      {/* Key Metrics using standardized MetricsGrid */}
+      <MetricsGrid metrics={metrics} columns={4} className="mb-8" />
 
           {/* Tab Content wrapped in SectionCard */}
           <SectionCard
@@ -104,14 +95,12 @@ export default function CACUnitEconomics() {
           </SectionCard>
 
           {/* Professional Narrative Sections wrapped in SectionCard */}
-          <SectionCard
-            title="Project Narrative"
-            description="Comprehensive case study following the STAR methodology"
-          >
-            <NarrativeSections />
-          </SectionCard>
-        </>
-      )}
+      <SectionCard
+        title="Project Narrative"
+        description="Comprehensive case study following the STAR methodology"
+      >
+        <NarrativeSections />
+      </SectionCard>
     </ProjectPageLayout>
   )
 }

--- a/src/app/projects/churn-retention/page.tsx
+++ b/src/app/projects/churn-retention/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useMemo } from 'react'
-import { useLoadingState } from '@/hooks/use-loading-state'
 import { useAnalyticsData } from '@/hooks/use-analytics-data'
 import dynamic from 'next/dynamic'
 import { TrendingDown, Users, Activity, AlertCircle } from 'lucide-react'
@@ -27,11 +26,9 @@ const RetentionHeatmap = dynamic(() => import('./RetentionHeatmap'), {
 import { staticChurnData } from '@/app/projects/data/partner-analytics'
 
 export default function ChurnAnalysis() {
-  const { isLoading: isUiLoading, handleRefresh: handleUiRefresh } = useLoadingState()
   const {
     data: analyticsData,
-    isLoading: isAnalyticsLoading,
-    refresh: refreshAnalyticsData,
+    isLoading,
   } = useAnalyticsData()
 
   const churnData = useMemo(
@@ -47,7 +44,6 @@ export default function ChurnAnalysis() {
     [analyticsData?.churn]
   )
 
-  const isLoading = isUiLoading || isAnalyticsLoading
 
   // Ensure data exists before accessing indices
   const currentMonth = churnData?.[churnData.length - 1] ?? null
@@ -146,11 +142,6 @@ export default function ChurnAnalysis() {
             variant: 'success' as const,
           },
         ]}
-        onRefresh={() => {
-          handleUiRefresh()
-          void refreshAnalyticsData()
-        }}
-        refreshButtonDisabled={isLoading}
       >
         {isLoading ? (
           <MetricsGrid metrics={metricsData} columns={4} loading={true} className="mb-12" />

--- a/src/app/projects/commission-optimization/components/NarrativeSections.tsx
+++ b/src/app/projects/commission-optimization/components/NarrativeSections.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { SectionCard } from '@/components/ui/section-card'
-import { ResultCard, TechGrid, FeatureCard } from '@/components/projects/shared'
-import { commissionMetrics, technologies } from '../data/constants'
+import { ResultCard, FeatureCard } from '@/components/projects/shared'
+import { commissionMetrics } from '../data/constants'
 import { formatCurrency, formatPercentage } from '@/lib/utils/data-formatters'
 
 export function NarrativeSections() {
@@ -168,9 +168,6 @@ export function NarrativeSections() {
           </p>
         </div>
       </SectionCard>
-
-      {/* Technologies Used */}
-      <TechGrid technologies={technologies} />
     </div>
   )
 }

--- a/src/app/projects/commission-optimization/page.tsx
+++ b/src/app/projects/commission-optimization/page.tsx
@@ -4,9 +4,7 @@ import { DollarSign, Percent, TrendingUp, Calculator } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 
 import { ProjectPageLayout } from '@/components/projects/project-page-layout'
-import { LoadingState } from '@/components/projects/loading-state'
 import { MetricsGrid } from '@/components/projects/metrics-grid'
-import { useLoadingState } from '@/hooks/use-loading-state'
 import { commissionMetrics } from './data/constants'
 import { formatCurrency, formatPercentage } from '@/lib/utils/data-formatters'
 import { ProcessingMetrics } from './components/ProcessingMetrics'
@@ -21,7 +19,6 @@ const tabs = ['overview', 'tiers', 'incentives', 'automation'] as const
 type Tab = (typeof tabs)[number]
 
 export default function CommissionOptimization() {
-  const { isLoading, handleRefresh } = useLoadingState()
   const [activeTab, setActiveTab] = useQueryState('tab', { defaultValue: 'overview' as Tab })
 
   // Standardized metrics configuration using design system types
@@ -82,19 +79,13 @@ export default function CommissionOptimization() {
           variant: 'secondary',
         },
       ]}
-      onRefresh={handleRefresh}
-      refreshButtonDisabled={isLoading}
       showTimeframes={true}
       timeframes={tabs.map((t) => t.charAt(0).toUpperCase() + t.slice(1))}
       activeTimeframe={activeTab.charAt(0).toUpperCase() + activeTab.slice(1)}
       onTimeframeChange={(timeframe) => setActiveTab(timeframe.toLowerCase() as Tab)}
     >
-      {isLoading ? (
-        <LoadingState />
-      ) : (
-        <>
           {/* Standardized Key Metrics Grid */}
-          <MetricsGrid metrics={metrics} columns={4} loading={isLoading} className="mb-8" />
+          <MetricsGrid metrics={metrics} columns={4} className="mb-8" />
 
           {/* Processing Metrics */}
           <ProcessingMetrics />
@@ -107,8 +98,6 @@ export default function CommissionOptimization() {
 
           {/* Professional Narrative Sections */}
           <NarrativeSections />
-        </>
-      )}
     </ProjectPageLayout>
   )
 }

--- a/src/app/projects/customer-lifetime-value/components/NarrativeSections.tsx
+++ b/src/app/projects/customer-lifetime-value/components/NarrativeSections.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { SectionCard } from '@/components/ui/section-card'
-import { ResultCard, TechGrid, FeatureCard } from '@/components/projects/shared'
-import { technologies } from '../data/constants'
+import { ResultCard, FeatureCard } from '@/components/projects/shared'
 import { formatCurrency } from '../utils'
 
 export function NarrativeSections() {
@@ -173,9 +172,6 @@ export function NarrativeSections() {
           </p>
         </div>
       </SectionCard>
-
-      {/* Technologies Used */}
-      <TechGrid technologies={technologies} />
     </div>
   )
 }

--- a/src/app/projects/customer-lifetime-value/page.tsx
+++ b/src/app/projects/customer-lifetime-value/page.tsx
@@ -4,10 +4,8 @@ import { DollarSign, Brain, Users, Calendar } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 
 import { ProjectPageLayout } from '@/components/projects/project-page-layout'
-import { LoadingState } from '@/components/projects/loading-state'
 import { MetricsGrid } from '@/components/projects/metrics-grid'
 import { SectionCard } from '@/components/ui/section-card'
-import { useLoadingState } from '@/hooks/use-loading-state'
 import { formatCurrency, formatNumber, formatPercentage } from '@/lib/utils/data-formatters'
 import { clvMetrics } from './data/constants'
 import { OverviewTab } from './components/OverviewTab'
@@ -20,7 +18,6 @@ const tabs = ['overview', 'segments', 'predictions'] as const
 type Tab = (typeof tabs)[number]
 
 export default function CustomerLifetimeValueAnalytics() {
-  const { isLoading, handleRefresh } = useLoadingState()
   const [activeTab, setActiveTab] = useQueryState('tab', { defaultValue: 'overview' as Tab })
 
   // Standardized metrics configuration using consistent data formatting
@@ -75,19 +72,13 @@ export default function CustomerLifetimeValueAnalytics() {
         { label: 'Machine Learning', variant: 'primary' },
         { label: 'BTYD Framework', variant: 'secondary' },
       ]}
-      onRefresh={handleRefresh}
-      refreshButtonDisabled={isLoading}
       showTimeframes={true}
       timeframes={tabs.map((t) => t.charAt(0).toUpperCase() + t.slice(1))}
       activeTimeframe={activeTab.charAt(0).toUpperCase() + activeTab.slice(1)}
       onTimeframeChange={(timeframe) => setActiveTab(timeframe.toLowerCase() as Tab)}
     >
-      {isLoading ? (
-        <LoadingState />
-      ) : (
-        <>
           {/* Key Metrics using standardized MetricsGrid */}
-          <MetricsGrid metrics={metrics} columns={4} loading={isLoading} className="mb-8" />
+          <MetricsGrid metrics={metrics} columns={4} className="mb-8" />
 
           {/* Tab Content wrapped in SectionCard */}
           <SectionCard
@@ -116,8 +107,6 @@ export default function CustomerLifetimeValueAnalytics() {
           >
             <NarrativeSections />
           </SectionCard>
-        </>
-      )}
     </ProjectPageLayout>
   )
 }

--- a/src/app/projects/data/partner-analytics/index.ts
+++ b/src/app/projects/data/partner-analytics/index.ts
@@ -140,21 +140,45 @@ export const monthlyRevenue2024 = [
 ]
 
 export const yearOverYearGrowthExtended = [
-  { 
-    year: 2023, 
-    total_revenue: 2940000, 
-    total_transactions: 1250, 
-    total_commissions: 294000, 
-    partner_count: 45, 
-    commission_growth_percentage: 12.5 
+  {
+    year: 2020,
+    total_revenue: 2100000,
+    total_transactions: 950,
+    total_commissions: 210000,
+    partner_count: 32,
+    commission_growth_percentage: 0
   },
-  { 
-    year: 2024, 
-    total_revenue: 3720000, 
-    total_transactions: 1580, 
-    total_commissions: 372000, 
-    partner_count: 58, 
-    commission_growth_percentage: 26.5 
+  {
+    year: 2021,
+    total_revenue: 2450000,
+    total_transactions: 1050,
+    total_commissions: 245000,
+    partner_count: 37,
+    commission_growth_percentage: 16.7
+  },
+  {
+    year: 2022,
+    total_revenue: 2850000,
+    total_transactions: 1180,
+    total_commissions: 285000,
+    partner_count: 42,
+    commission_growth_percentage: 16.3
+  },
+  {
+    year: 2023,
+    total_revenue: 3350000,
+    total_transactions: 1350,
+    total_commissions: 335000,
+    partner_count: 48,
+    commission_growth_percentage: 17.5
+  },
+  {
+    year: 2024,
+    total_revenue: 4250000,
+    total_transactions: 1650,
+    total_commissions: 425000,
+    partner_count: 62,
+    commission_growth_percentage: 26.9
   }
 ]
 

--- a/src/app/projects/deal-funnel/components/NarrativeSections.tsx
+++ b/src/app/projects/deal-funnel/components/NarrativeSections.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { SectionCard } from '@/components/ui/section-card'
-import { ResultCard, TechGrid, FeatureCard } from '@/components/projects/shared'
-import { technologies } from '../data/constants'
+import { ResultCard, FeatureCard } from '@/components/projects/shared'
 
 export function NarrativeSections() {
   return (
@@ -87,20 +86,15 @@ export function NarrativeSections() {
         <div className="space-y-6 text-muted-foreground">
           <p className="leading-relaxed">
             The deal funnel analytics system I built transformed how we manage our pipeline
-            and delivered measurable revenue impact:
+            and delivered measurable improvements:
           </p>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <ResultCard value="27%" label="Overall Conversion Rate Improvement" variant="primary" />
             <ResultCard
               value="31 Days"
               label="Reduction in Average Sales Cycle"
               variant="secondary"
-            />
-            <ResultCard
-              value="$2.8M"
-              label="Additional Pipeline Value Captured"
-              variant="primary"
             />
           </div>
 
@@ -173,9 +167,6 @@ export function NarrativeSections() {
           </p>
         </div>
       </SectionCard>
-
-      {/* Technologies Used */}
-      <TechGrid technologies={technologies} />
     </div>
   )
 }

--- a/src/app/projects/deal-funnel/page.tsx
+++ b/src/app/projects/deal-funnel/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { DollarSign, Clock, Target, BarChart3 } from 'lucide-react'
 
 import { ProjectPageLayout } from '@/components/projects/project-page-layout'
@@ -25,7 +25,6 @@ import {
 import { FunnelChart } from './components/FunnelChart'
 import { ConversionChart } from './components/ConversionChart'
 import { VelocityChart } from './components/VelocityChart'
-import { PipelineValue } from './components/PipelineValue'
 import { NarrativeSections } from './components/NarrativeSections'
 
 const logger = createContextLogger('DealFunnelPage')
@@ -61,15 +60,6 @@ export default function DealFunnel() {
       }
     }
     loadProjectData()
-  }, [])
-
-  const handleRefresh = useCallback(() => {
-    if (timeoutRef.current) clearTimeout(timeoutRef.current)
-    setIsLoading(true)
-    setLocalFunnelStages(initialFunnelStages)
-    setLocalPartnerConversion(initialPartnerConversion)
-    setLocalConversionRates(initialConversionRates)
-    timeoutRef.current = setTimeout(() => setIsLoading(false), TIMING.LOADING_STATE_RESET)
   }, [])
 
   // Derived calculations
@@ -186,8 +176,6 @@ export default function DealFunnel() {
             variant: 'secondary',
           },
         ]}
-        onRefresh={handleRefresh}
-        refreshButtonDisabled={isLoading}
       >
         {isLoading ? (
           <LoadingState />
@@ -245,14 +233,6 @@ export default function DealFunnel() {
               className="mb-8"
             >
               <NarrativeSections />
-            </SectionCard>
-
-            {/* Revenue Impact wrapped in SectionCard */}
-            <SectionCard
-              title="Revenue Impact"
-              description="Financial impact and business value generated from pipeline optimization"
-            >
-              <PipelineValue totalRevenue={totalRevenue} />
             </SectionCard>
           </>
         )}

--- a/src/app/projects/forecast-pipeline-intelligence/components/NarrativeSections.tsx
+++ b/src/app/projects/forecast-pipeline-intelligence/components/NarrativeSections.tsx
@@ -4,20 +4,6 @@ import { SectionCard } from '@/components/ui/section-card'
 import { ResultCard, FeatureCard } from '@/components/projects/shared'
 import { formatCurrency, formatPercentage } from '@/lib/utils/data-formatters'
 
-const _technologies = [
-  'Python',
-  'Machine Learning',
-  'Time Series Analysis',
-  'Plotly',
-  'Recharts',
-  'PostgreSQL',
-  'Next.js',
-  'TypeScript',
-  'Predictive Analytics',
-  'Real-time Processing',
-  'Salesforce Integration',
-  'Data Modeling',
-]
 
 export function NarrativeSections() {
   return (

--- a/src/app/projects/forecast-pipeline-intelligence/components/NarrativeSections.tsx
+++ b/src/app/projects/forecast-pipeline-intelligence/components/NarrativeSections.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { SectionCard } from '@/components/ui/section-card'
-import { ResultCard, TechGrid, FeatureCard } from '@/components/projects/shared'
+import { ResultCard, FeatureCard } from '@/components/projects/shared'
 import { formatCurrency, formatPercentage } from '@/lib/utils/data-formatters'
 
-const technologies = [
+const _technologies = [
   'Python',
   'Machine Learning',
   'Time Series Analysis',
@@ -194,9 +194,6 @@ export function NarrativeSections() {
           </p>
         </div>
       </SectionCard>
-
-      {/* Technologies Used */}
-      <TechGrid technologies={technologies} />
     </div>
   )
 }

--- a/src/app/projects/forecast-pipeline-intelligence/page.tsx
+++ b/src/app/projects/forecast-pipeline-intelligence/page.tsx
@@ -3,10 +3,8 @@
 import { TrendingUp, AlertTriangle, Zap, CheckCircle, BarChart3 } from 'lucide-react'
 
 import { ProjectPageLayout } from '@/components/projects/project-page-layout'
-import { LoadingState } from '@/components/projects/loading-state'
 import { MetricsGrid } from '@/components/projects/metrics-grid'
 import { SectionCard } from '@/components/ui/section-card'
-import { useLoadingState } from '@/hooks/use-loading-state'
 import {
   formatCurrency,
   formatNumber,
@@ -17,7 +15,6 @@ import { ProjectJsonLd } from '@/components/seo/json-ld'
 import { NarrativeSections } from './components/NarrativeSections'
 
 export default function ForecastPipelineIntelligenceProject() {
-  const { isLoading, handleRefresh } = useLoadingState()
 
   // Standardized metrics configuration using consistent data formatting
   const metrics = [
@@ -131,15 +128,9 @@ export default function ForecastPipelineIntelligenceProject() {
           { label: `${formatNumber(4200)}+ Deals Monitored`, variant: 'primary' },
           { label: `${formatPercentage(0.89)} Early Warnings`, variant: 'secondary' },
         ]}
-        onRefresh={handleRefresh}
-        refreshButtonDisabled={isLoading}
       >
-        {isLoading ? (
-          <LoadingState />
-        ) : (
-          <>
             {/* Key Metrics using standardized MetricsGrid */}
-            <MetricsGrid metrics={metrics} columns={4} loading={isLoading} className="mb-8" />
+            <MetricsGrid metrics={metrics} columns={4} className="mb-8" />
 
             {/* Intelligence Modules wrapped in SectionCard */}
             <SectionCard
@@ -239,8 +230,6 @@ export default function ForecastPipelineIntelligenceProject() {
 
             {/* Professional Narrative Sections - STAR Method */}
             <NarrativeSections />
-          </>
-        )}
       </ProjectPageLayout>
     </>
   )

--- a/src/app/projects/lead-attribution/components/NarrativeSections.tsx
+++ b/src/app/projects/lead-attribution/components/NarrativeSections.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { SectionCard } from '@/components/ui/section-card'
-import { ResultCard, TechGrid, FeatureCard } from '@/components/projects/shared'
-import { technologies } from '../data/constants'
+import { ResultCard, FeatureCard } from '@/components/projects/shared'
 
 export function NarrativeSections() {
   return (
@@ -187,9 +186,6 @@ export function NarrativeSections() {
           </p>
         </div>
       </SectionCard>
-
-      {/* Technologies Used */}
-      <TechGrid technologies={technologies} />
     </div>
   )
 }

--- a/src/app/projects/lead-attribution/page.tsx
+++ b/src/app/projects/lead-attribution/page.tsx
@@ -20,7 +20,6 @@ import { MetricsGrid } from '@/components/projects/metrics-grid'
 import { SectionCard } from '@/components/ui/section-card'
 import { ChartContainer } from '@/components/ui/chart-container'
 import { ProjectJsonLd } from '@/components/seo/json-ld'
-import { useLoadingState } from '@/hooks/use-loading-state'
 import { useAnalyticsData } from '@/hooks/use-analytics-data'
 import { formatNumber, formatPercentage, formatTrend } from '@/lib/utils/data-formatters'
 import { leadAttributionData } from '@/app/projects/data/partner-analytics'
@@ -32,11 +31,9 @@ import { InsightsSection } from './components/InsightsSection'
 import { NarrativeSections } from './components/NarrativeSections'
 
 export default function LeadAttribution() {
-  const { isLoading: isUiLoading, handleRefresh: handleUiRefresh } = useLoadingState()
   const {
     data: analyticsData,
-    isLoading: isAnalyticsLoading,
-    refresh: refreshAnalyticsData,
+    isLoading,
   } = useAnalyticsData()
 
   const leadSources = useMemo(() => {
@@ -122,7 +119,6 @@ export default function LeadAttribution() {
       ? ((lastMonth.leads - prevMonth.leads) / prevMonth.leads) * 100
       : 0
 
-  const isLoading = isUiLoading || isAnalyticsLoading
 
   // Standardized metrics configuration using consistent data formatting
   const metrics = [
@@ -189,11 +185,6 @@ export default function LeadAttribution() {
             variant: 'secondary',
           },
         ]}
-        onRefresh={() => {
-          handleUiRefresh()
-          void refreshAnalyticsData()
-        }}
-        refreshButtonDisabled={isLoading}
       >
         {isLoading ? (
           <LoadingState />

--- a/src/app/projects/multi-channel-attribution/components/NarrativeSections.tsx
+++ b/src/app/projects/multi-channel-attribution/components/NarrativeSections.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { SectionCard } from '@/components/ui/section-card'
-import { ResultCard, TechGrid, FeatureCard } from '@/components/projects/shared'
-import { attributionMetrics, technologies } from '../data/constants'
+import { ResultCard, FeatureCard } from '@/components/projects/shared'
+import { attributionMetrics } from '../data/constants'
 import { formatCurrency } from '../utils'
 
 export function NarrativeSections() {
@@ -185,9 +185,6 @@ export function NarrativeSections() {
           </p>
         </div>
       </SectionCard>
-
-      {/* Technologies Used */}
-      <TechGrid technologies={technologies} />
     </div>
   )
 }

--- a/src/app/projects/multi-channel-attribution/page.tsx
+++ b/src/app/projects/multi-channel-attribution/page.tsx
@@ -4,10 +4,8 @@ import { Target, Eye, Share2, DollarSign } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 
 import { ProjectPageLayout } from '@/components/projects/project-page-layout'
-import { LoadingState } from '@/components/projects/loading-state'
 import { MetricsGrid } from '@/components/projects/metrics-grid'
 import { SectionCard } from '@/components/ui/section-card'
-import { useLoadingState } from '@/hooks/use-loading-state'
 import { formatCurrency, formatNumber } from '@/lib/utils/data-formatters'
 import { attributionMetrics } from './data/constants'
 import { formatPercent } from './utils'
@@ -22,7 +20,6 @@ const tabs = ['overview', 'models', 'journeys', 'channels'] as const
 type Tab = (typeof tabs)[number]
 
 export default function MultiChannelAttribution() {
-  const { isLoading, handleRefresh } = useLoadingState()
   const [activeTab, setActiveTab] = useQueryState('tab', { defaultValue: 'overview' as Tab })
 
   // Standardized metrics configuration using consistent data formatting
@@ -82,19 +79,13 @@ export default function MultiChannelAttribution() {
         { label: 'ML Attribution Models', variant: 'primary' },
         { label: 'Customer Journey Analytics', variant: 'secondary' },
       ]}
-      onRefresh={handleRefresh}
-      refreshButtonDisabled={isLoading}
       showTimeframes={true}
       timeframes={tabs.map((t) => t.charAt(0).toUpperCase() + t.slice(1))}
       activeTimeframe={activeTab.charAt(0).toUpperCase() + activeTab.slice(1)}
       onTimeframeChange={(timeframe) => setActiveTab(timeframe.toLowerCase() as Tab)}
     >
-      {isLoading ? (
-        <LoadingState />
-      ) : (
-        <>
           {/* Key Metrics using standardized MetricsGrid */}
-          <MetricsGrid metrics={metrics} columns={4} loading={isLoading} className="mb-8" />
+          <MetricsGrid metrics={metrics} columns={4} className="mb-8" />
 
           {/* Tab Content wrapped in SectionCard */}
           <SectionCard
@@ -124,8 +115,6 @@ export default function MultiChannelAttribution() {
           >
             <NarrativeSections />
           </SectionCard>
-        </>
-      )}
     </ProjectPageLayout>
   )
 }

--- a/src/app/projects/partner-performance/components/NarrativeSections.tsx
+++ b/src/app/projects/partner-performance/components/NarrativeSections.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { SectionCard } from '@/components/ui/section-card'
-import { ResultCard, TechGrid, FeatureCard } from '@/components/projects/shared'
+import { ResultCard, FeatureCard } from '@/components/projects/shared'
 import { formatCurrency, formatPercentage } from '@/lib/utils/data-formatters'
 
-const technologies = [
+const _technologies = [
   'React',
   'TypeScript',
   'Recharts',
@@ -195,9 +195,6 @@ export function NarrativeSections() {
           </p>
         </div>
       </SectionCard>
-
-      {/* Technologies Used */}
-      <TechGrid technologies={technologies} />
     </div>
   )
 }

--- a/src/app/projects/partner-performance/components/NarrativeSections.tsx
+++ b/src/app/projects/partner-performance/components/NarrativeSections.tsx
@@ -4,20 +4,6 @@ import { SectionCard } from '@/components/ui/section-card'
 import { ResultCard, FeatureCard } from '@/components/projects/shared'
 import { formatCurrency, formatPercentage } from '@/lib/utils/data-formatters'
 
-const _technologies = [
-  'React',
-  'TypeScript',
-  'Recharts',
-  'Next.js',
-  'PostgreSQL',
-  'Data Analytics',
-  'Salesforce Integration',
-  'Business Intelligence',
-  'Partner Management',
-  'Revenue Attribution',
-  'Cohort Analysis',
-  'Performance Metrics',
-]
 
 export function NarrativeSections() {
   return (

--- a/src/app/projects/partner-performance/page.tsx
+++ b/src/app/projects/partner-performance/page.tsx
@@ -5,11 +5,9 @@ import { TrendingUp, Users, Target, DollarSign } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 
 import { ProjectPageLayout } from '@/components/projects/project-page-layout'
-import { LoadingState } from '@/components/projects/loading-state'
 import { MetricsGrid } from '@/components/projects/metrics-grid'
 import { SectionCard } from '@/components/ui/section-card'
 import { ChartContainer } from '@/components/ui/chart-container'
-import { useLoadingState } from '@/hooks/use-loading-state'
 import { formatCurrency, formatNumber, formatPercentage } from '@/lib/utils/data-formatters'
 import { NarrativeSections } from './components/NarrativeSections'
 
@@ -94,7 +92,6 @@ const tabs = ['overview', 'tiers', 'top-performers'] as const
 type Tab = (typeof tabs)[number]
 
 export default function PartnerPerformanceIntelligence() {
-  const { isLoading, handleRefresh } = useLoadingState()
   const [activeTab, setActiveTab] = useQueryState('tab', { defaultValue: 'overview' as Tab })
 
   // Standardized metrics configuration using consistent data formatting
@@ -146,8 +143,6 @@ export default function PartnerPerformanceIntelligence() {
         { label: 'Partner Intelligence', variant: 'primary' },
         { label: 'Revenue Operations', variant: 'secondary' },
       ]}
-      onRefresh={handleRefresh}
-      refreshButtonDisabled={isLoading}
       showTimeframes={true}
       timeframes={tabs.map((t) => t.charAt(0).toUpperCase() + t.slice(1).replace('-', ' '))}
       activeTimeframe={activeTab.charAt(0).toUpperCase() + activeTab.slice(1).replace('-', ' ')}
@@ -156,12 +151,8 @@ export default function PartnerPerformanceIntelligence() {
         setActiveTab(tab)
       }}
     >
-      {isLoading ? (
-        <LoadingState />
-      ) : (
-        <>
           {/* Key Metrics using standardized MetricsGrid */}
-          <MetricsGrid metrics={metrics} columns={4} loading={isLoading} className="mb-8" />
+          <MetricsGrid metrics={metrics} columns={4} className="mb-8" />
 
           {/* Tab Content wrapped in SectionCard */}
           <SectionCard
@@ -343,8 +334,6 @@ export default function PartnerPerformanceIntelligence() {
 
           {/* Professional Narrative Sections - STAR Method */}
           <NarrativeSections />
-        </>
-      )}
     </ProjectPageLayout>
   )
 }

--- a/src/app/projects/partnership-program-implementation/page.tsx
+++ b/src/app/projects/partnership-program-implementation/page.tsx
@@ -3,8 +3,6 @@
 import { TrendingUp, Users, Settings, BarChart } from 'lucide-react'
 
 import { ProjectPageLayout } from '@/components/projects/project-page-layout'
-import { LoadingState } from '@/components/projects/loading-state'
-import { useLoadingState } from '@/hooks/use-loading-state'
 import { ProjectJsonLd } from '@/components/seo/json-ld'
 
 const achievements = [
@@ -63,7 +61,6 @@ const technicalDetails = [
 ]
 
 export default function PartnershipProgramPage() {
-  const { isLoading, handleRefresh } = useLoadingState()
 
   return (
     <>
@@ -89,13 +86,7 @@ export default function PartnershipProgramPage() {
           { label: 'Full Production', variant: 'primary' },
           { label: 'Strategic Success', variant: 'secondary' },
         ]}
-        onRefresh={handleRefresh}
-        refreshButtonDisabled={isLoading}
       >
-        {isLoading ? (
-          <LoadingState />
-        ) : (
-          <>
             {/* Key Achievements */}
             <div className="space-y-12 mb-16">
               <div className="text-center space-y-4">
@@ -310,9 +301,6 @@ export default function PartnershipProgramPage() {
                 </div>
               </div>
             </div>
-
-          </>
-        )}
       </ProjectPageLayout>
     </>
   )

--- a/src/app/projects/quota-territory-management/components/NarrativeSections.tsx
+++ b/src/app/projects/quota-territory-management/components/NarrativeSections.tsx
@@ -4,20 +4,6 @@ import { SectionCard } from '@/components/ui/section-card'
 import { ResultCard, FeatureCard } from '@/components/projects/shared'
 import { formatCurrency, formatPercentage, formatNumber } from '@/lib/utils/data-formatters'
 
-const _technologies = [
-  'Python',
-  'Machine Learning',
-  'Predictive Analytics',
-  'D3.js',
-  'Recharts',
-  'PostgreSQL',
-  'Next.js',
-  'TypeScript',
-  'Geospatial Analysis',
-  'Regression Modeling',
-  'Clustering Algorithms',
-  'Time Series Forecasting',
-]
 
 export function NarrativeSections() {
   return (

--- a/src/app/projects/quota-territory-management/components/NarrativeSections.tsx
+++ b/src/app/projects/quota-territory-management/components/NarrativeSections.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { SectionCard } from '@/components/ui/section-card'
-import { ResultCard, TechGrid, FeatureCard } from '@/components/projects/shared'
+import { ResultCard, FeatureCard } from '@/components/projects/shared'
 import { formatCurrency, formatPercentage, formatNumber } from '@/lib/utils/data-formatters'
 
-const technologies = [
+const _technologies = [
   'Python',
   'Machine Learning',
   'Predictive Analytics',
@@ -197,9 +197,6 @@ export function NarrativeSections() {
           </p>
         </div>
       </SectionCard>
-
-      {/* Technologies Used */}
-      <TechGrid technologies={technologies} />
     </div>
   )
 }

--- a/src/app/projects/quota-territory-management/page.tsx
+++ b/src/app/projects/quota-territory-management/page.tsx
@@ -3,10 +3,8 @@
 import { TrendingUp, Map, Database, Zap, Code, Check } from 'lucide-react'
 
 import { ProjectPageLayout } from '@/components/projects/project-page-layout'
-import { LoadingState } from '@/components/projects/loading-state'
 import { MetricsGrid } from '@/components/projects/metrics-grid'
 import { SectionCard } from '@/components/ui/section-card'
-import { useLoadingState } from '@/hooks/use-loading-state'
 import {
   formatCurrency,
   formatNumber,
@@ -17,7 +15,6 @@ import { ProjectJsonLd } from '@/components/seo/json-ld'
 import { NarrativeSections } from './components/NarrativeSections'
 
 export default function QuotaTerritoryManagementProject() {
-  const { isLoading, handleRefresh } = useLoadingState()
 
   // Standardized metrics configuration using consistent data formatting
   const metrics = [
@@ -131,15 +128,9 @@ export default function QuotaTerritoryManagementProject() {
             variant: 'secondary',
           },
         ]}
-        onRefresh={handleRefresh}
-        refreshButtonDisabled={isLoading}
       >
-        {isLoading ? (
-          <LoadingState />
-        ) : (
-          <>
             {/* Key Metrics using standardized MetricsGrid */}
-            <MetricsGrid metrics={metrics} columns={4} loading={isLoading} className="mb-8" />
+            <MetricsGrid metrics={metrics} columns={4} className="mb-8" />
 
             {/* Algorithmic Approaches wrapped in SectionCard */}
             <SectionCard
@@ -238,8 +229,6 @@ export default function QuotaTerritoryManagementProject() {
 
             {/* Professional Narrative Sections - STAR Method */}
             <NarrativeSections />
-          </>
-        )}
       </ProjectPageLayout>
     </>
   )

--- a/src/app/projects/revenue-kpi/components/NarrativeSections.tsx
+++ b/src/app/projects/revenue-kpi/components/NarrativeSections.tsx
@@ -1,9 +1,8 @@
 'use client'
 
 import { SectionCard } from '@/components/ui/section-card'
-import { ResultCard, TechGrid, FeatureCard } from '@/components/projects/shared'
+import { ResultCard, FeatureCard } from '@/components/projects/shared'
 import { formatCurrency } from '@/lib/utils/data-formatters'
-import { technologies } from '../data/constants'
 
 interface NarrativeSectionsProps {
   totalRevenue: number
@@ -170,9 +169,6 @@ export function NarrativeSections({ totalRevenue }: NarrativeSectionsProps) {
           </p>
         </div>
       </SectionCard>
-
-      {/* Technologies Used */}
-      <TechGrid technologies={technologies} />
     </div>
   )
 }

--- a/src/app/projects/revenue-kpi/page.tsx
+++ b/src/app/projects/revenue-kpi/page.tsx
@@ -5,7 +5,6 @@ import { TrendingUp, DollarSign, Users, Activity } from 'lucide-react'
 
 import { ProjectJsonLd } from '@/components/seo/json-ld'
 import { createContextLogger } from '@/lib/monitoring/logger'
-import { useLoadingState } from '@/hooks/use-loading-state'
 import { useAnalyticsData } from '@/hooks/use-analytics-data'
 import {
   monthlyRevenue2024,
@@ -14,8 +13,8 @@ import {
   yearOverYearGrowthExtended,
 } from '@/app/projects/data/partner-analytics'
 import { ProjectPageLayout } from '@/components/projects/project-page-layout'
-import { LoadingState } from '@/components/projects/loading-state'
 import { MetricsGrid } from '@/components/projects/metrics-grid'
+import { LoadingState } from '@/components/projects/loading-state'
 import { formatCurrency, formatNumber, formatPercentage } from '@/lib/utils/data-formatters'
 
 import type { GrowthData, YearOverYearData } from '@/lib/analytics/data-service'
@@ -39,12 +38,10 @@ type PartnerSeries = {
 
 export default function RevenueKPI() {
   const [activeTimeframe, setActiveTimeframe] = useState('All')
-  const { isLoading: isUiLoading, handleRefresh: handleUiRefresh } = useLoadingState()
   const {
     data: analyticsData,
-    isLoading: isAnalyticsLoading,
+    isLoading,
     error: analyticsError,
-    refresh: refreshAnalyticsData,
   } = useAnalyticsData()
 
   const yearOverYearData: YearOverYearSeries[] = analyticsData?.yearOverYear?.length
@@ -104,11 +101,6 @@ export default function RevenueKPI() {
       }))
       .sort((a, b) => b.value - a.value)
   }, [topPartners])
-
-  const handleRefresh = () => {
-    handleUiRefresh()
-    void refreshAnalyticsData()
-  }
 
   if (!currentYearData) {
     logger.error(
@@ -196,7 +188,6 @@ export default function RevenueKPI() {
     },
   ]
 
-  const isLoading = isUiLoading || isAnalyticsLoading
 
   return (
     <>
@@ -238,8 +229,6 @@ export default function RevenueKPI() {
         timeframes={timeframes}
         activeTimeframe={activeTimeframe}
         onTimeframeChange={setActiveTimeframe}
-        onRefresh={handleRefresh}
-        refreshButtonDisabled={isLoading}
       >
         {isLoading ? (
           <LoadingState />

--- a/src/app/projects/revenue-operations-center/components/NarrativeSections.tsx
+++ b/src/app/projects/revenue-operations-center/components/NarrativeSections.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { SectionCard } from '@/components/ui/section-card'
-import { ResultCard, TechGrid, FeatureCard } from '@/components/projects/shared'
-import { technologies } from '../data/constants'
+import { ResultCard, FeatureCard } from '@/components/projects/shared'
 
 export function NarrativeSections() {
   return (
@@ -180,9 +179,6 @@ export function NarrativeSections() {
           </p>
         </div>
       </SectionCard>
-
-      {/* Technologies Used */}
-      <TechGrid technologies={technologies} />
     </div>
   )
 }

--- a/src/app/projects/revenue-operations-center/page.tsx
+++ b/src/app/projects/revenue-operations-center/page.tsx
@@ -4,8 +4,6 @@ import { DollarSign, Target, BarChart3, Users, Activity } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 
 import { ProjectPageLayout } from '@/components/projects/project-page-layout'
-import { LoadingState } from '@/components/projects/loading-state'
-import { useLoadingState } from '@/hooks/use-loading-state'
 import { revenueMetrics } from './data/constants'
 import { formatCurrency, formatPercent } from './utils'
 import { MetricCard } from '@/components/ui/metric-card'
@@ -21,7 +19,6 @@ const tabs = ['overview', 'pipeline', 'forecasting', 'operations'] as const
 type Tab = (typeof tabs)[number]
 
 export default function RevenueOperationsCenter() {
-  const { isLoading, handleRefresh } = useLoadingState()
   const [activeTab, setActiveTab] = useQueryState('tab', { defaultValue: 'overview' as Tab })
 
   return (
@@ -34,17 +31,11 @@ export default function RevenueOperationsCenter() {
         { label: 'Revenue Growth: +34.2%', variant: 'primary' },
         { label: 'Operations Dashboard', variant: 'secondary' },
       ]}
-      onRefresh={handleRefresh}
-      refreshButtonDisabled={isLoading}
       showTimeframes={true}
       timeframes={tabs.map((t) => t.charAt(0).toUpperCase() + t.slice(1))}
       activeTimeframe={activeTab.charAt(0).toUpperCase() + activeTab.slice(1)}
       onTimeframeChange={(timeframe) => setActiveTab(timeframe.toLowerCase() as Tab)}
     >
-      {isLoading ? (
-        <LoadingState />
-      ) : (
-        <>
           {/* Key Metrics Grid */}
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-6 mb-12">
             <MetricCard
@@ -98,8 +89,6 @@ export default function RevenueOperationsCenter() {
 
           {/* Professional Narrative Sections */}
           <NarrativeSections />
-        </>
-      )}
     </ProjectPageLayout>
   )
 }

--- a/src/app/projects/sales-enablement/components/NarrativeSections.tsx
+++ b/src/app/projects/sales-enablement/components/NarrativeSections.tsx
@@ -4,20 +4,6 @@ import { SectionCard } from '@/components/ui/section-card'
 import { ResultCard, FeatureCard } from '@/components/projects/shared'
 import { formatCurrency, formatPercentage, formatNumber } from '@/lib/utils/data-formatters'
 
-const _technologies = [
-  'React',
-  'Next.js',
-  'TypeScript',
-  'Recharts',
-  'Tailwind CSS',
-  'PostgreSQL',
-  'Node.js',
-  'Learning Management System',
-  'Content Management',
-  'Video Production',
-  'Analytics Platform',
-  'CRM Integration',
-]
 
 export function NarrativeSections() {
   return (

--- a/src/app/projects/sales-enablement/components/NarrativeSections.tsx
+++ b/src/app/projects/sales-enablement/components/NarrativeSections.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { SectionCard } from '@/components/ui/section-card'
-import { ResultCard, TechGrid, FeatureCard } from '@/components/projects/shared'
+import { ResultCard, FeatureCard } from '@/components/projects/shared'
 import { formatCurrency, formatPercentage, formatNumber } from '@/lib/utils/data-formatters'
 
-const technologies = [
+const _technologies = [
   'React',
   'Next.js',
   'TypeScript',
@@ -193,9 +193,6 @@ export function NarrativeSections() {
           </p>
         </div>
       </SectionCard>
-
-      {/* Technologies Used */}
-      <TechGrid technologies={technologies} />
     </div>
   )
 }

--- a/src/app/projects/sales-enablement/page.tsx
+++ b/src/app/projects/sales-enablement/page.tsx
@@ -3,10 +3,8 @@
 import { TrendingUp, Users, Zap, BookOpen, Check } from 'lucide-react'
 
 import { ProjectPageLayout } from '@/components/projects/project-page-layout'
-import { LoadingState } from '@/components/projects/loading-state'
 import { MetricsGrid } from '@/components/projects/metrics-grid'
 import { SectionCard } from '@/components/ui/section-card'
-import { useLoadingState } from '@/hooks/use-loading-state'
 import {
   formatCurrency,
   formatNumber,
@@ -17,7 +15,6 @@ import { ProjectJsonLd } from '@/components/seo/json-ld'
 import { NarrativeSections } from './components/NarrativeSections'
 
 export default function SalesEnablementProject() {
-  const { isLoading, handleRefresh } = useLoadingState()
 
   // Standardized metrics configuration using consistent data formatting
   const metrics = [
@@ -123,15 +120,9 @@ export default function SalesEnablementProject() {
           { label: `${formatNumber(125)} Sales Team Members`, variant: 'primary' },
           { label: `${formatNumber(450)}+ Content Pieces`, variant: 'secondary' },
         ]}
-        onRefresh={handleRefresh}
-        refreshButtonDisabled={isLoading}
       >
-        {isLoading ? (
-          <LoadingState />
-        ) : (
-          <>
             {/* Key Metrics using standardized MetricsGrid */}
-            <MetricsGrid metrics={metrics} columns={4} loading={isLoading} className="mb-8" />
+            <MetricsGrid metrics={metrics} columns={4} className="mb-8" />
 
             {/* Implementation Pillars wrapped in SectionCard */}
             <SectionCard
@@ -205,8 +196,6 @@ export default function SalesEnablementProject() {
 
             {/* Professional Narrative Sections - STAR Method */}
             <NarrativeSections />
-          </>
-        )}
       </ProjectPageLayout>
     </>
   )

--- a/src/components/projects/project-detail-client-boundary.tsx
+++ b/src/components/projects/project-detail-client-boundary.tsx
@@ -135,7 +135,6 @@ export default function ProjectDetailClientBoundary({
               backUrl: '/projects',
               backLabel: 'Back to Projects',
             }}
-            onRefresh={handleRetry}
           >
             {/* Main Content Grid */}
             <div className="grid lg:grid-cols-2 gap-8">

--- a/src/components/projects/project-page-layout.tsx
+++ b/src/components/projects/project-page-layout.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import * as React from 'react'
-import { RefreshCcw } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -29,8 +28,6 @@ export const ProjectPageLayout = React.forwardRef<HTMLDivElement, ProjectPageLay
       timeframes = [],
       activeTimeframe,
       onTimeframeChange,
-      onRefresh,
-      refreshButtonDisabled = false,
       className,
       ...props
     },
@@ -101,22 +98,6 @@ export const ProjectPageLayout = React.forwardRef<HTMLDivElement, ProjectPageLay
                     </Button>
                   ))}
                 </div>
-              )}
-
-              {/* Refresh Button */}
-              {onRefresh && (
-                <Button
-                  variant="outline"
-                  size="icon"
-                  onClick={onRefresh}
-                  disabled={refreshButtonDisabled}
-                  data-testid="refresh-button"
-                  className="shadow-sm"
-                  aria-label="Refresh data"
-                >
-                  <RefreshCcw className="h-4 w-4" />
-                  <span className="sr-only">Refresh data</span>
-                </Button>
               )}
             </div>
           </header>

--- a/src/lib/design-system/types.ts
+++ b/src/lib/design-system/types.ts
@@ -116,8 +116,6 @@ export interface ProjectPageLayoutProps {
   timeframes?: string[]
   activeTimeframe?: string
   onTimeframeChange?: (timeframe: string) => void
-  onRefresh?: () => void
-  refreshButtonDisabled?: boolean
   className?: string
 }
 


### PR DESCRIPTION
- Remove refresh button UI from ProjectPageLayout component
- Clean up onRefresh and refreshButtonDisabled props from all project pages
- Remove unused useLoadingState hook calls and refresh handlers
- Update TypeScript interfaces to remove refresh-related props
- Enhance revenue analytics with 5-year historical data (2020-2024)
- Show accelerating commission growth trend (102% over 5 years)

This removes demo-only functionality that doesn't serve a purpose with static portfolio data, resulting in cleaner UX and -205 LOC.