### PR TITLE
audit/actionable-fixes: security hardening, deps, docs, tests, palette, nav, OG

### DIFF
--- a/src/app/api/blog/analytics/route.ts
+++ b/src/app/api/blog/analytics/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
 import { ApiResponse, BlogAnalyticsData } from '@/types/api'
 import { createContextLogger } from '@/lib/logger'
 import { db } from '@/lib/db'
@@ -8,6 +9,9 @@ import {
   transformToTagData,
   createErrorResponse,
 } from '@/lib/api-blog'
+
+// Enum must stay in lockstep with getStartDate's switch cases below.
+const timeRangeSchema = z.enum(['7d', '30d', '90d', '1y']).default('30d')
 
 const logger = createContextLogger('AnalyticsAPI')
 
@@ -37,7 +41,15 @@ function getStartDate(timeRange: string): Date {
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
-    const timeRange = searchParams.get('timeRange') || '30d'
+    const timeRangeParam = searchParams.get('timeRange')
+    const timeRangeResult = timeRangeSchema.safeParse(timeRangeParam ?? undefined)
+    if (!timeRangeResult.success) {
+      return NextResponse.json(
+        createErrorResponse('Invalid timeRange; must be one of 7d, 30d, 90d, 1y'),
+        { status: 400 }
+      )
+    }
+    const timeRange = timeRangeResult.data
     const includeDetails = searchParams.get('details') === 'true'
     const startDate = getStartDate(timeRange)
 

--- a/src/app/api/blog/route.ts
+++ b/src/app/api/blog/route.ts
@@ -169,6 +169,14 @@ export async function POST(request: NextRequest) {
         keywords: body.keywords,
         canonicalUrl: body.canonicalUrl || undefined,
 
+        // Social card fields (OG + Twitter)
+        ogTitle: body.ogTitle,
+        ogDescription: body.ogDescription,
+        ogImage: body.ogImage || undefined,
+        twitterTitle: body.twitterTitle,
+        twitterDescription: body.twitterDescription,
+        twitterImage: body.twitterImage || undefined,
+
         // Content metadata
         featuredImage: body.featuredImage || undefined,
         featuredImageAlt: body.featuredImageAlt,

--- a/src/app/api/blog/route.ts
+++ b/src/app/api/blog/route.ts
@@ -12,6 +12,7 @@ import {
   createErrorResponse,
   generateSlug,
 } from '@/lib/api-blog'
+import { createBlogPostSchema } from '@/lib/schemas'
 
 const logger = createContextLogger('BlogAPI')
 
@@ -128,14 +129,13 @@ export async function POST(request: NextRequest) {
   if (csrfResponse) return csrfResponse
 
   try {
-    const body = await request.json()
-
-    // Validate required fields
-    if (!body.title || !body.content || !body.authorId) {
-      return NextResponse.json(createErrorResponse('Missing required fields: title, content, authorId'), {
-        status: 400,
-      })
+    const raw = await request.json()
+    const parsed = createBlogPostSchema.safeParse(raw)
+    if (!parsed.success) {
+      logger.warn('Blog POST validation failed', { issues: parsed.error.flatten() })
+      return NextResponse.json(createErrorResponse('Invalid request body'), { status: 400 })
     }
+    const body = parsed.data
 
     // Generate slug using shared utility
     const slug = generateSlug(body.title)
@@ -160,17 +160,17 @@ export async function POST(request: NextRequest) {
         slug,
         excerpt: body.excerpt,
         content: body.content,
-        contentType: body.contentType || 'MARKDOWN',
-        status: body.status || 'DRAFT',
+        contentType: body.contentType,
+        status: body.status,
 
         // SEO fields
         metaTitle: body.metaTitle,
         metaDescription: body.metaDescription,
-        keywords: body.keywords || [],
-        canonicalUrl: body.canonicalUrl,
+        keywords: body.keywords,
+        canonicalUrl: body.canonicalUrl || undefined,
 
         // Content metadata
-        featuredImage: body.featuredImage,
+        featuredImage: body.featuredImage || undefined,
         featuredImageAlt: body.featuredImageAlt,
         readingTime,
         wordCount,
@@ -192,7 +192,7 @@ export async function POST(request: NextRequest) {
         tags:
           body.tagIds && body.tagIds.length > 0
             ? {
-                create: body.tagIds.map((tagId: string) => ({
+                create: body.tagIds.map((tagId) => ({
                   tagId,
                 })),
               }

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -4,50 +4,39 @@ import { logger } from '@/lib/logger'
 
 export async function GET() {
   try {
-    // Check database connectivity
     await db.$queryRaw`SELECT 1`
 
-    // Check basic system health
-    const healthCheck = {
-      status: 'healthy',
-      timestamp: new Date().toISOString(),
-      uptime: process.uptime(),
-      memory: process.memoryUsage(),
-      version: process.env.bun_package_version || 'unknown',
-      environment: process.env.NODE_ENV || 'development',
-    }
+    logger.info('Health check performed', { status: 'healthy' })
 
-    logger.info('Health check performed', { status: healthCheck.status })
-
-    return NextResponse.json(healthCheck, {
-      headers: {
-        'Cache-Control': 'no-cache, no-store, must-revalidate',
-        'Content-Type': 'application/json',
+    return NextResponse.json(
+      {
+        status: 'healthy',
+        database: 'up',
+        timestamp: new Date().toISOString(),
       },
-    })
+      {
+        headers: {
+          'Cache-Control': 'no-cache, no-store, must-revalidate',
+          'Content-Type': 'application/json',
+        },
+      }
+    )
   } catch (error) {
     logger.error('Health check failed', error instanceof Error ? error : new Error(String(error)))
 
-    // Don't expose internal error details in production
-    const errorResponse = {
-      status: 'unhealthy',
-      timestamp: new Date().toISOString(),
-      error:
-        process.env.NODE_ENV === 'production'
-          ? 'Health check failed'
-          : error instanceof Error
-            ? error.message
-            : 'Unknown error',
-      version: process.env.bun_package_version || 'unknown',
-      environment: process.env.NODE_ENV || 'development',
-    }
-
-    return NextResponse.json(errorResponse, {
-      status: 503,
-      headers: {
-        'Cache-Control': 'no-cache, no-store, must-revalidate',
-        'Content-Type': 'application/json',
+    return NextResponse.json(
+      {
+        status: 'unhealthy',
+        database: 'down',
+        timestamp: new Date().toISOString(),
       },
-    })
+      {
+        status: 503,
+        headers: {
+          'Cache-Control': 'no-cache, no-store, must-revalidate',
+          'Content-Type': 'application/json',
+        },
+      }
+    )
   }
 }

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,12 +1,21 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { getProjects } from '@/lib/projects'
 import { createApiSuccessResponse, createApiErrorResponse } from '@/lib/api-response'
 import { ApiErrorType } from '@/types/api'
+import { checkRateLimitOrRespond, RateLimitPresets } from '@/lib/api-rate-limit'
 
 // Enable ISR with 1 hour revalidation
 export const revalidate = 3600
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const rateLimitResponse = checkRateLimitOrRespond(
+    request,
+    RateLimitPresets.read,
+    '/api/projects',
+    'GET'
+  )
+  if (rateLimitResponse) return rateLimitResponse
+
   try {
     const projects = await getProjects()
     const response = createApiSuccessResponse(projects)

--- a/src/app/api/seed/route.ts
+++ b/src/app/api/seed/route.ts
@@ -20,6 +20,15 @@ function isAuthorized(request: NextRequest): boolean {
 }
 
 export async function POST(request: NextRequest) {
+  // Production gate: endpoint is invisible in production unless explicitly opted in.
+  // Returns 404 (not 401) so the route's existence isn't advertised to unauthenticated callers.
+  if (env.NODE_ENV === 'production' && env.ALLOW_SEED_IN_PRODUCTION !== 'true') {
+    return NextResponse.json(
+      { success: false, error: 'Not found' },
+      { status: 404 }
+    );
+  }
+
   if (!isAuthorized(request)) {
     logger.warn('Unauthorized seed attempt', { route: 'api/seed' });
     return NextResponse.json(
@@ -170,7 +179,7 @@ In the age of big data, making decisions based on intuition alone is no longer s
     );
     return NextResponse.json({
       success: false,
-      error: error instanceof Error ? error.message : 'Unknown error'
+      error: 'Seeding failed'
     }, { status: 500 });
   }
 }

--- a/src/app/api/sentry-debug/route.ts
+++ b/src/app/api/sentry-debug/route.ts
@@ -1,10 +1,29 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import * as Sentry from '@sentry/nextjs'
+import { env } from '@/lib/env-validation'
+import { checkRateLimitOrRespond, RateLimitPresets } from '@/lib/api-rate-limit'
 
 /**
- * Debug endpoint to check Sentry configuration
+ * Debug endpoint to check Sentry configuration.
+ * Hidden in production (returns 404) so DSN host and env-var presence flags
+ * aren't exposed to the public internet.
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
+  if (env.NODE_ENV === 'production') {
+    return NextResponse.json(
+      { success: false, error: 'Not found' },
+      { status: 404 }
+    )
+  }
+
+  const rateLimitResponse = checkRateLimitOrRespond(
+    request,
+    RateLimitPresets.read,
+    '/api/sentry-debug',
+    'GET'
+  )
+  if (rateLimitResponse) return rateLimitResponse
+
   const client = Sentry.getClient()
   const options = client?.getOptions()
 

--- a/src/lib/env-validation.ts
+++ b/src/lib/env-validation.ts
@@ -38,6 +38,8 @@ const envSchema = z.object({
   ADMIN_API_TOKEN: z.string()
     .min(32, 'ADMIN_API_TOKEN must be at least 32 characters')
     .optional(),
+  // Production seed gate — /api/seed returns 404 in production unless set to 'true'
+  ALLOW_SEED_IN_PRODUCTION: z.enum(['true', 'false']).optional(),
   // Metrics API authentication
   METRICS_API_TOKEN: z.string()
     .min(32, 'METRICS_API_TOKEN must be at least 32 characters')

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -121,6 +121,36 @@ export const contactFormSchema = z.object({
 export type ContactFormValues = z.infer<typeof contactFormSchema>
 
 // =======================
+// BLOG POST SCHEMAS
+// =======================
+
+// Input schema for POST /api/blog — validates request body before Prisma create.
+// Uses cuidSchema (not uuid) because Prisma generates cuid IDs.
+// .strict() rejects unknown fields so mass-assignment attempts fail loudly.
+export const createBlogPostSchema = z
+  .object({
+    title: z.string().min(1, 'Title is required').max(200, 'Title cannot exceed 200 characters'),
+    content: z.string().min(1, 'Content is required').max(100_000, 'Content cannot exceed 100,000 characters'),
+    authorId: cuidSchema,
+    excerpt: z.string().max(500).optional(),
+    contentType: ContentTypeSchema.default(ContentType.MARKDOWN),
+    status: PostStatusSchema.default(PostStatus.DRAFT),
+    metaTitle: z.string().max(100).optional(),
+    metaDescription: metaDescriptionSchema,
+    keywords: keywordsSchema,
+    canonicalUrl: optionalUrlSchema,
+    featuredImage: optionalUrlSchema,
+    featuredImageAlt: z.string().max(200).optional(),
+    categoryId: cuidSchema.optional(),
+    tagIds: z.array(cuidSchema).max(10, 'Cannot attach more than 10 tags').optional(),
+    publishedAt: datetimeSchema.optional(),
+    scheduledAt: datetimeSchema.optional(),
+  })
+  .strict()
+
+export type CreateBlogPostInput = z.infer<typeof createBlogPostSchema>
+
+// =======================
 // PROJECT SCHEMAS
 // =======================
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -139,6 +139,13 @@ export const createBlogPostSchema = z
     metaDescription: metaDescriptionSchema,
     keywords: keywordsSchema,
     canonicalUrl: optionalUrlSchema,
+    // Social card fields — match Prisma BlogPost model; max lengths come from @db.VarChar constraints
+    ogTitle: z.string().max(100).optional(),
+    ogDescription: z.string().max(300).optional(),
+    ogImage: optionalUrlSchema,
+    twitterTitle: z.string().max(100).optional(),
+    twitterDescription: z.string().max(200).optional(),
+    twitterImage: optionalUrlSchema,
     featuredImage: optionalUrlSchema,
     featuredImageAlt: z.string().max(200).optional(),
     categoryId: cuidSchema.optional(),


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m 
[38;5;8m   3[0m [37mBatched cleanup and hardening branch spanning several work items:[0m
[38;5;8m   4[0m 
[38;5;8m   5[0m [37m- **Security audit follow-through** (latest commit, `4b4b207`): closes 3 real gaps (prod gate on `/api/seed` and `/api/sentry-debug`, Zod schema on `/api/blog` POST) and 3 lower-risk tightenings (health endpoint info-leak, `timeRange` enum validation on analytics, rate-limit on `/api/projects`). 3 audit items were stale (projects/[slug] already validated, `postgres-store.ts` doesn't exist, resume-pdf route is 503-disabled) — documented in the commit instead of changed.[0m
[38;5;8m   6[0m [37m- **`/api/seed` hardening**: earlier commits added Bearer + timing-safe comparison, flipped GET→POST, and fixed an idempotency-log ordering bug. This PR adds the final production gate + error-message redaction.[0m
[38;5;8m   7[0m [37m- **Dependency audit**: `bun audit --audit-level=high` → 0 remaining after patching 16 findings via direct bump (swiper 12.1.3) and npm-style overrides (defu, vite 8.0.5, minimatch 9, serialize-javascript, flatted, rollup, picomatch).[0m
[38;5;8m   8[0m [37m- **Docs**: root README, SECURITY.md, LICENSE, `.env.example` written from a complete env audit. Replaces the false claim that Vercel runs `db:migrate:deploy` during build.[0m
[38;5;8m   9[0m [37m- **Tests**: env-validation (11 new tests), contact route (4 tests, mocked Resend class), re-enabled vitest on pre-push via lefthook. Full suite: 176 passing.[0m
[38;5;8m  10[0m [37m- **Palette conformance**: every UI surface swapped to the luxury-minimalist tokens (primary navy / secondary forest / accent bronze). Arbitrary hex, pink/purple/burgundy, and dark-mode stacks removed. Opacity-only mask-image fades preserved.[0m
[38;5;8m  11[0m [37m- **Navbar single source of truth**: `mainNav` now comes from `navConfig`, Blog membership restored, Cmd+K + JSON-LD + Navbar all agree. Unskipped the Blog navigation JSON-LD test.[0m
[38;5;8m  12[0m [37m- **OG + Edge runtime**: dropped the `runtime = 'edge'` declaration on `/api/og` to eliminate the static-generation build warning.[0m
[38;5;8m  13[0m [37m- **React Compiler**: enabled in Next.js 16 via `reactCompiler: true` with `babel-plugin-react-compiler@1.0.0` installed as a required peer.[0m
[38;5;8m  14[0m [37m- **Misc**: `vite-tsconfig-paths` removed in favor of explicit `resolve.alias`; stray `console.*` calls routed through `@/lib/logger` so they reach Sentry; home page trimmed of Salesloft/HubSpot badges.[0m
[38;5;8m  15[0m 
[38;5;8m  16[0m [37m## Test plan[0m
[38;5;8m  17[0m 
[38;5;8m  18[0m [37m- [x] `bun run typecheck` → clean[0m
[38;5;8m  19[0m [37m- [x] `bunx vitest run` → 176 passed[0m
[38;5;8m  20[0m [37m- [x] `bun run build` → clean (38 routes, 12.9s wall time)[0m
[38;5;8m  21[0m [37m- [x] `bun audit --audit-level=high` → 0 vulnerabilities[0m
[38;5;8m  22[0m [37m- [ ] Preview deploy sanity: seed/sentry-debug return 404 in prod, health exposes `{status, database, timestamp}` only, blog POST rejects unknown fields, /api/blog/analytics returns 400 on `timeRange=bogus`[0m
[38;5;8m  23[0m 
[38;5;8m  24[0m [37m## Notes on audit discrepancies (for reviewers)[0m
[38;5;8m  25[0m 
[38;5;8m  26[0m [37m- Audit suggested `z.string().uuid()` for `authorId` on blog POST — **wrong for this codebase**: Prisma generates cuid IDs. Schema uses `cuidSchema` instead.[0m
[38;5;8m  27[0m [37m- Audit's B-002 described `dateFrom`/`dateTo`; the real field is `timeRange`. Re-characterized and fixed.[0m
[38;5;8m  28[0m [37m- Audit's R-001 referenced `src/lib/rate-limiter/postgres-store.ts` which doesn't exist in this tree (rate limiter is in-memory lazy singleton in `store.ts`). No action.[0m
[38;5;8m  29[0m 
[38;5;8m  30[0m [37m[hudsor01][0m