### PR TITLE
chore: close Sentry coverage gaps across server, RSC, server action, and code-split

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -45,4 +45,14 @@ Sentry.init({
     ? (integrations) => [...integrations, Sentry.replayIntegration()]
     : undefined,
   sendDefaultPii: process.env.NEXT_PUBLIC_SENTRY_SEND_DEFAULT_PII === 'true',
+  ignoreErrors: [
+    // Browser benign noise
+    /^ResizeObserver loop limit exceeded$/,
+    /^ResizeObserver loop completed with undelivered notifications/,
+    'Non-Error promise rejection captured',
+    'AbortError',
+    // Next.js client-side control flow
+    /^NEXT_REDIRECT/,
+    /^NEXT_NOT_FOUND$/,
+  ],
 })

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -28,4 +28,5 @@ Sentry.init({
   tracesSampleRate,
   profilesSampleRate,
   sendDefaultPii: process.env.SENTRY_SEND_DEFAULT_PII === 'true',
+  ignoreErrors: [/^NEXT_REDIRECT/, /^NEXT_NOT_FOUND$/, /^NEXT_HTTP_ERROR_FALLBACK$/],
 })

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -28,4 +28,7 @@ Sentry.init({
   tracesSampleRate,
   profilesSampleRate,
   sendDefaultPii: process.env.SENTRY_SEND_DEFAULT_PII === 'true',
+  // Next.js uses thrown sentinels for redirect()/notFound() control flow.
+  // These are not bugs and would otherwise drown real errors.
+  ignoreErrors: [/^NEXT_REDIRECT/, /^NEXT_NOT_FOUND$/, /^NEXT_HTTP_ERROR_FALLBACK$/],
 })

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -87,7 +87,7 @@ const BENTO_FEATURES = [
 const PERSONAL_INFO = {
   name: 'Richard Hudson',
   title: 'Revenue Operations Professional',
-  location: 'Plano, TX • Serving Dallas-Fort Worth Metroplex • Remote & On-Site Available',
+  location: 'Dallas, TX • Serving Dallas-Fort Worth Metroplex • Remote & On-Site Available',
   email: 'contact@richardwhudsonjr.com',
   bio: `Started my career untangling spreadsheet chaos at a 50-person startup. Built my first automated pipeline with zero engineering support—just Excel, determination, and 3 YouTube tutorials. That pipeline now processes $4.8M+ annually.
 
@@ -95,7 +95,7 @@ Today, I architect revenue operations systems that transform data overwhelm into
 
 SalesLoft Admin certified (Level 1 & 2), HubSpot Revenue Operations certified, and obsessed with making complex systems feel simple. I specialize in the messy middle—where sales meets marketing meets customer success—and everything needs to actually work together.`,
   highlights: [
-    'Based in Plano, TX with deep knowledge of Dallas-Fort Worth business ecosystem and market dynamics',
+    'Based in Dallas, TX with deep knowledge of Dallas-Fort Worth business ecosystem and market dynamics',
     'SalesLoft Admin Certified (Level 1 & 2) and HubSpot Revenue Operations Certified professional',
     'Specialized in revenue operations and growth analytics with proven $4.8M+ revenue generation track record',
     'Expert in partnership program development and implementation with 432% growth achievements',
@@ -133,7 +133,7 @@ export default function AboutPage() {
         },
         {
           question: 'Where is Richard Hudson located?',
-          answer: 'Richard is based in Plano, Texas, serving the Dallas-Fort Worth metroplex area.',
+          answer: 'Richard is based in Dallas, Texas, serving the Dallas-Fort Worth metroplex area.',
         },
       ]} />
       <BreadcrumbListJsonLd items={[

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -111,7 +111,7 @@ SalesLoft Admin certified (Level 1 & 2), HubSpot Revenue Operations certified, a
 export const dynamic = 'force-static'
 export const metadata: Metadata = generateMetadata(
   'About Richard Hudson | Revenue Operations Professional | Dallas-Fort Worth',
-  'Richard Hudson - Plano, Texas Revenue Operations Professional serving Dallas-Fort Worth metroplex with 10+ years experience. SalesLoft Admin certified (Level 1 & 2) and HubSpot Revenue Operations certified. Partnership program implementation specialist with system integration experience. Expert in data analytics, process automation, and CRM optimization. $4.8M+ revenue generated across 10+ projects, 432% transaction growth achieved.',
+  'Richard Hudson - Dallas, Texas Revenue Operations Professional serving Dallas-Fort Worth metroplex with 10+ years experience. SalesLoft Admin certified (Level 1 & 2) and HubSpot Revenue Operations certified. Partnership program implementation specialist with system integration experience. Expert in data analytics, process automation, and CRM optimization. $4.8M+ revenue generated across 10+ projects, 432% transaction growth achieved.',
   '/about'
 )
 

--- a/src/app/api/blog/[slug]/route.ts
+++ b/src/app/api/blog/[slug]/route.ts
@@ -48,7 +48,13 @@ export async function GET(_request: NextRequest, context: { params: Promise<{ sl
         where: { id: post.id },
         data: { viewCount: { increment: 1 } },
       })
-      .catch((err) => logger.error('Failed to increment view count', err))
+      .catch((err) =>
+        logger.error(
+          'Failed to increment view count',
+          err instanceof Error ? err : new Error(String(err)),
+          { slug: post.slug, postId: post.id }
+        )
+      )
 
     const response: ApiResponse<BlogPostData> = {
       data: transformToBlogPostData(post),

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -5,6 +5,9 @@ import { contactFormSchema } from '@/lib/schemas'
 import { escapeHtml } from '@/lib/sanitization'
 import { env } from '@/lib/env-validation'
 import { validateCSRFOrRespond } from '@/lib/api-csrf'
+import { createContextLogger } from '@/lib/logger'
+
+const logger = createContextLogger('ContactAPI')
 
 let resend: Resend | null = null
 
@@ -70,6 +73,10 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    logger.error(
+      'Contact API submission failed',
+      error instanceof Error ? error : new Error(String(error))
+    )
     return NextResponse.json(
       { success: false, error: 'Error processing form' },
       { status: 500 }

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -6,8 +6,11 @@ import { Footer } from '@/components/layout/footer'
 import { BlogPostLayout } from '../_components/blog-post-layout'
 import { BlogPostJsonLd } from '@/components/seo/blog-json-ld'
 import { transformToBlogPostData } from '@/lib/api-blog'
+import { createContextLogger } from '@/lib/logger'
 import type { BlogPostData } from '@/types/api'
 import { db } from '@/lib/db'
+
+const logger = createContextLogger('BlogPost')
 
 interface BlogPostPageProps {
   params: Promise<{
@@ -43,8 +46,14 @@ const getBlogPost = cache(async (slug: string): Promise<BlogPostData | null> => 
     if (!post) return null
 
     return transformToBlogPostData(post)
-  } catch {
-    // Database not available - return null
+  } catch (error) {
+    if (process.env.NEXT_PHASE !== 'phase-production-build') {
+      logger.error(
+        'Blog post query failed',
+        error instanceof Error ? error : new Error(String(error)),
+        { slug }
+      )
+    }
     return null
   }
 })
@@ -159,8 +168,13 @@ export async function generateStaticParams() {
     })
 
     return posts.map((post) => ({ slug: post.slug }))
-  } catch {
-    // Database not available - return empty array
+  } catch (error) {
+    if (process.env.NEXT_PHASE !== 'phase-production-build') {
+      logger.error(
+        'generateStaticParams blog slug query failed',
+        error instanceof Error ? error : new Error(String(error))
+      )
+    }
     // Pages will be generated on-demand at runtime
     return []
   }

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -6,7 +6,10 @@ import { BlogList } from './_components/blog-list'
 import { BlogJsonLd } from '@/components/seo/blog-json-ld'
 import { db } from '@/lib/db'
 import { transformToBlogPostData } from '@/lib/api-blog'
+import { createContextLogger } from '@/lib/logger'
 import type { BlogPostData, BlogCategoryData } from '@/types/api'
+
+const logger = createContextLogger('BlogIndex')
 
 const BLOG_INDEX_OG_IMAGE_URL = `https://richardwhudsonjr.com/api/og?${new URLSearchParams({
   title: 'Blog | Richard Hudson',
@@ -68,8 +71,13 @@ const getBlogPosts = cache(async (): Promise<BlogPostData[]> => {
     })
 
     return posts.map(transformToBlogPostData)
-  } catch {
-    // Database not available - return empty array
+  } catch (error) {
+    if (process.env.NEXT_PHASE !== 'phase-production-build') {
+      logger.error(
+        'Blog index posts query failed',
+        error instanceof Error ? error : new Error(String(error))
+      )
+    }
     return []
   }
 })
@@ -96,8 +104,13 @@ const getCategories = cache(async (): Promise<BlogCategoryData[]> => {
       totalViews: cat.totalViews,
       createdAt: cat.createdAt.toISOString()
     }))
-  } catch {
-    // Database not available - return empty array
+  } catch (error) {
+    if (process.env.NEXT_PHASE !== 'phase-production-build') {
+      logger.error(
+        'Blog categories query failed',
+        error instanceof Error ? error : new Error(String(error))
+      )
+    }
     return []
   }
 })

--- a/src/app/contact/actions.ts
+++ b/src/app/contact/actions.ts
@@ -1,10 +1,14 @@
 'use server'
 
 import { headers } from 'next/headers'
+import * as Sentry from '@sentry/nextjs'
 import { Resend } from 'resend'
 import { checkContactFormRateLimit } from '@/lib/rate-limiter/helpers'
 import { contactFormSchema } from '@/lib/schemas'
 import { escapeHtml } from '@/lib/sanitization'
+import { createContextLogger } from '@/lib/logger'
+
+const logger = createContextLogger('ContactAction')
 
 // Initialize Resend
 let resend: Resend | null = null
@@ -24,64 +28,75 @@ function getResendClient(): Resend {
  * Handles validation and email sending
  */
 export async function submitContactForm(formData: unknown) {
-  try {
-    // Validate form data with Zod schema
-    const validatedData = contactFormSchema.parse(formData)
+  return Sentry.withServerActionInstrumentation(
+    'submitContactForm',
+    { recordResponse: true },
+    async () => {
+      try {
+        // Validate form data with Zod schema
+        const validatedData = contactFormSchema.parse(formData)
 
-    // Rate limiting check using IP-based identification
-    const headersList = await headers()
-    const forwarded = headersList.get('x-forwarded-for')
-    const ip = (forwarded ? forwarded.split(/, /)[0] : headersList.get('x-real-ip')) || 'unknown'
+        // Rate limiting check using IP-based identification
+        const headersList = await headers()
+        const forwarded = headersList.get('x-forwarded-for')
+        const ip = (forwarded ? forwarded.split(/, /)[0] : headersList.get('x-real-ip')) || 'unknown'
 
-    const rateLimitResult = checkContactFormRateLimit(`${ip}`, {
-      path: '/contact'
-    })
+        const rateLimitResult = checkContactFormRateLimit(`${ip}`, {
+          path: '/contact'
+        })
 
-    if (!rateLimitResult.allowed) {
-      return {
-        success: false,
-        error: 'Too many contact form submissions. Please try again later.',
+        if (!rateLimitResult.allowed) {
+          return {
+            success: false,
+            error: 'Too many contact form submissions. Please try again later.',
+          }
+        }
+
+        // Validate that CONTACT_EMAIL is configured
+        const contactEmail = process.env.CONTACT_EMAIL
+        if (!contactEmail) {
+          logger.error('Contact form server action misconfigured: CONTACT_EMAIL missing')
+          return {
+            success: false,
+            error: 'Email service misconfigured. Please try again later.',
+          }
+        }
+
+        // Send email using Resend
+        const { name, email, message } = validatedData
+
+        await getResendClient().emails.send({
+          from: 'Portfolio Contact <hello@richardwhudsonjr.com>',
+          to: contactEmail,
+          replyTo: email,
+          subject: `New Contact from ${escapeHtml(name)}`,
+          text: `Name: ${name}\nEmail: ${email}\n\nMessage:\n${message}`,
+          html: `<div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;"><h2 style="color: #1e293b; border-bottom: 2px solid #3b82f6; padding-bottom: 8px;">New Contact Form Submission</h2><p><strong>From:</strong> ${escapeHtml(name)}</p><p><strong>Email:</strong> <a href="mailto:${escapeHtml(email)}">${escapeHtml(email)}</a></p><div style="background: #f8fafc; padding: 16px; border-radius: 8px; margin-top: 16px;"><p><strong>Message:</strong></p><p style="white-space: pre-wrap;">${escapeHtml(message).replace(/\n/g, '<br>')}</p></div></div>`,
+        })
+
+        return {
+          success: true,
+          message: 'Form submitted successfully! I will get back to you soon.',
+        }
+      } catch (error) {
+        // Validation errors are user-driven, not bugs — surface and skip telemetry.
+        if (error instanceof Error && error.name === 'ZodError') {
+          return {
+            success: false,
+            error: 'Please check your form and try again.',
+          }
+        }
+
+        // Anything else is a real failure (Resend down, header read, etc.).
+        logger.error(
+          'Contact form server action failed',
+          error instanceof Error ? error : new Error(String(error))
+        )
+        return {
+          success: false,
+          error: 'An unexpected error occurred. Please try again later.',
+        }
       }
     }
-
-    // Validate that CONTACT_EMAIL is configured
-    const contactEmail = process.env.CONTACT_EMAIL
-    if (!contactEmail) {
-      return {
-        success: false,
-        error: 'Email service misconfigured. Please try again later.',
-      }
-    }
-
-    // Send email using Resend
-    const { name, email, message } = validatedData
-
-    await getResendClient().emails.send({
-      from: 'Portfolio Contact <hello@richardwhudsonjr.com>',
-      to: contactEmail,
-      replyTo: email,
-      subject: `New Contact from ${escapeHtml(name)}`,
-      text: `Name: ${name}\nEmail: ${email}\n\nMessage:\n${message}`,
-      html: `<div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;"><h2 style="color: #1e293b; border-bottom: 2px solid #3b82f6; padding-bottom: 8px;">New Contact Form Submission</h2><p><strong>From:</strong> ${escapeHtml(name)}</p><p><strong>Email:</strong> <a href="mailto:${escapeHtml(email)}">${escapeHtml(email)}</a></p><div style="background: #f8fafc; padding: 16px; border-radius: 8px; margin-top: 16px;"><p><strong>Message:</strong></p><p style="white-space: pre-wrap;">${escapeHtml(message).replace(/\n/g, '<br>')}</p></div></div>`,
-    })
-
-    return {
-      success: true,
-      message: 'Form submitted successfully! I will get back to you soon.',
-    }
-  } catch (error) {
-    // Handle validation errors
-    if (error instanceof Error && error.name === 'ZodError') {
-      return {
-        success: false,
-        error: 'Please check your form and try again.',
-      }
-    }
-
-    // Handle other errors
-    return {
-      success: false,
-      error: 'An unexpected error occurred. Please try again later.',
-    }
-  }
+  )
 }

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,15 +1,21 @@
 'use client'
 
+import { useEffect } from 'react'
+import * as Sentry from '@sentry/nextjs'
 import { Button } from '@/components/ui/button'
 import { RefreshCw, AlertTriangle } from 'lucide-react'
 
 export default function ErrorPage({
-  error: _error,
+  error,
   reset
 }: Readonly<{
   error: Error & { digest?: string }
   reset: () => void
 }>) {
+  useEffect(() => {
+    Sentry.captureException(error)
+  }, [error])
+
   return (
     <div className="flex items-center justify-center min-h-screen p-4 bg-background">
       <div className="w-full max-w-md text-center">

--- a/src/app/projects/cac-unit-economics/_components/OverviewTab.tsx
+++ b/src/app/projects/cac-unit-economics/_components/OverviewTab.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { safeLazy } from '@/lib/safe-lazy'
 import { ChartContainer } from '@/components/ui/chart-container'
 
 function ChartLoadError() {
@@ -12,7 +13,7 @@ function ChartLoadError() {
 }
 
 const CACBreakdownChart = dynamic(
-  () => import('./CACBreakdownChart').catch(() => ({ default: ChartLoadError })),
+  safeLazy(() => import('./CACBreakdownChart'), 'CACBreakdownChart', ChartLoadError),
   {
     loading: () => <div className="h-[var(--chart-height-sm)] w-full animate-pulse bg-muted rounded-lg" />,
     ssr: false,
@@ -20,7 +21,7 @@ const CACBreakdownChart = dynamic(
 )
 
 const UnitEconomicsChart = dynamic(
-  () => import('./UnitEconomicsChart').catch(() => ({ default: ChartLoadError })),
+  safeLazy(() => import('./UnitEconomicsChart'), 'UnitEconomicsChart', ChartLoadError),
   {
     loading: () => <div className="h-[var(--chart-height-sm)] w-full animate-pulse bg-muted rounded-lg" />,
     ssr: false,

--- a/src/app/projects/customer-lifetime-value/_components/OverviewTab.tsx
+++ b/src/app/projects/customer-lifetime-value/_components/OverviewTab.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { safeLazy } from '@/lib/safe-lazy'
 
 
 function ChartLoadError() {
@@ -12,7 +13,7 @@ function ChartLoadError() {
 }
 
 const CLVPredictionChart = dynamic(
-  () => import('./CLVPredictionChart').catch(() => ({ default: ChartLoadError })),
+  safeLazy(() => import('./CLVPredictionChart'), 'CLVPredictionChart', ChartLoadError),
   {
     loading: () => <div className="h-[var(--chart-height-sm)] w-full animate-pulse bg-muted rounded-lg" />,
     ssr: false
@@ -20,7 +21,7 @@ const CLVPredictionChart = dynamic(
 )
 
 const CLVTrendChart = dynamic(
-  () => import('./CLVTrendChart').catch(() => ({ default: ChartLoadError })),
+  safeLazy(() => import('./CLVTrendChart'), 'CLVTrendChart', ChartLoadError),
   {
     loading: () => <div className="h-[var(--chart-height-sm)] w-full animate-pulse bg-muted rounded-lg" />,
     ssr: false

--- a/src/app/projects/customer-lifetime-value/_components/SegmentsTab.tsx
+++ b/src/app/projects/customer-lifetime-value/_components/SegmentsTab.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { safeLazy } from '@/lib/safe-lazy'
 
 import { customerSegments } from '../data/constants'
 import { formatCurrency, formatPercent } from '../utils'
@@ -14,7 +15,7 @@ function ChartLoadError() {
 }
 
 const CustomerSegmentChart = dynamic(
-  () => import('./CustomerSegmentChart').catch(() => ({ default: ChartLoadError })),
+  safeLazy(() => import('./CustomerSegmentChart'), 'CustomerSegmentChart', ChartLoadError),
   {
     loading: () => <div className="h-[var(--chart-height-sm)] w-full animate-pulse bg-muted rounded-lg" />,
     ssr: false

--- a/src/app/projects/deal-funnel/_components/FunnelChart.tsx
+++ b/src/app/projects/deal-funnel/_components/FunnelChart.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { safeLazy } from '@/lib/safe-lazy'
 
 import type { FunnelStage } from '../data/constants'
 
@@ -13,7 +14,7 @@ function ChartLoadError() {
 }
 
 const DealStageFunnelChart = dynamic(
-  () => import('./DealStageFunnelChart').catch(() => ({ default: ChartLoadError })),
+  safeLazy(() => import('./DealStageFunnelChart'), 'DealStageFunnelChart', ChartLoadError),
   {
     loading: () => <div className="h-[var(--chart-height-md)] w-full animate-pulse bg-muted rounded-lg" />,
     ssr: false

--- a/src/app/projects/lead-attribution/_components/ChartsGrid.tsx
+++ b/src/app/projects/lead-attribution/_components/ChartsGrid.tsx
@@ -2,6 +2,7 @@
 
 import type { ComponentType, SVGProps } from 'react'
 import dynamic from 'next/dynamic'
+import { safeLazy } from '@/lib/safe-lazy'
 
 function ChartLoadError() {
   return (
@@ -12,7 +13,7 @@ function ChartLoadError() {
 }
 
 const LeadSourcePieChart = dynamic(
-  () => import('./LeadSourcePieChart').catch(() => ({ default: ChartLoadError })),
+  safeLazy(() => import('./LeadSourcePieChart'), 'LeadSourcePieChart', ChartLoadError),
   {
     loading: () => <div className="h-[var(--chart-height-md)] w-full animate-pulse bg-muted rounded-lg" />,
     ssr: false

--- a/src/app/projects/revenue-operations-center/_components/ForecastingTab.tsx
+++ b/src/app/projects/revenue-operations-center/_components/ForecastingTab.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { safeLazy } from '@/lib/safe-lazy'
 
 
 function ChartLoadError() {
@@ -12,7 +13,7 @@ function ChartLoadError() {
 }
 
 const ForecastAccuracyChart = dynamic(
-  () => import('./ForecastAccuracyChart').catch(() => ({ default: ChartLoadError })),
+  safeLazy(() => import('./ForecastAccuracyChart'), 'ForecastAccuracyChart', ChartLoadError),
   {
     loading: () => <div className="h-[var(--chart-height-md)] w-full animate-pulse bg-muted rounded-lg" />,
     ssr: false

--- a/src/app/projects/revenue-operations-center/_components/OverviewTab.tsx
+++ b/src/app/projects/revenue-operations-center/_components/OverviewTab.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { safeLazy } from '@/lib/safe-lazy'
 
 
 function ChartLoadError() {
@@ -12,7 +13,7 @@ function ChartLoadError() {
 }
 
 const RevenueOverviewChart = dynamic(
-  () => import('./RevenueOverviewChart').catch(() => ({ default: ChartLoadError })),
+  safeLazy(() => import('./RevenueOverviewChart'), 'RevenueOverviewChart', ChartLoadError),
   {
     loading: () => <div className="h-[var(--chart-height-md)] w-full animate-pulse bg-muted rounded-lg" />,
     ssr: false
@@ -20,7 +21,7 @@ const RevenueOverviewChart = dynamic(
 )
 
 const OperationalMetricsChart = dynamic(
-  () => import('./OperationalMetricsChart').catch(() => ({ default: ChartLoadError })),
+  safeLazy(() => import('./OperationalMetricsChart'), 'OperationalMetricsChart', ChartLoadError),
   {
     loading: () => <div className="h-[var(--chart-height-md)] w-full animate-pulse bg-muted rounded-lg" />,
     ssr: false

--- a/src/app/projects/revenue-operations-center/_components/PipelineTab.tsx
+++ b/src/app/projects/revenue-operations-center/_components/PipelineTab.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { safeLazy } from '@/lib/safe-lazy'
 
 
 function ChartLoadError() {
@@ -12,7 +13,7 @@ function ChartLoadError() {
 }
 
 const PipelineHealthChart = dynamic(
-  () => import('./PipelineHealthChart').catch(() => ({ default: ChartLoadError })),
+  safeLazy(() => import('./PipelineHealthChart'), 'PipelineHealthChart', ChartLoadError),
   {
     loading: () => <div className="h-[var(--chart-height-md)] w-full animate-pulse bg-muted rounded-lg" />,
     ssr: false

--- a/src/app/resume/view/resume-view-client.tsx
+++ b/src/app/resume/view/resume-view-client.tsx
@@ -43,7 +43,7 @@ const ResumeViewClient = React.memo(function ResumeViewClient() {
               Richard Hudson - Resume
             </h1>
             <p className="text-lg text-muted-foreground mb-8">
-              Revenue Operations Professional | Plano, TX
+              Revenue Operations Professional | Dallas, TX
             </p>
 
             {/* Action Buttons */}

--- a/src/app/shared-metadata.ts
+++ b/src/app/shared-metadata.ts
@@ -7,14 +7,13 @@ export const baseMetadata: Metadata = {
     template: '%s | Richard Hudson',
   },
   description:
-    'Revenue Operations Professional Richard Hudson specializes in sales automation, CRM optimization, and partnership program development across Dallas-Fort Worth metroplex. SalesLoft Admin Certified (Level 1 & 2) and HubSpot Revenue Operations Certified. $4.8M+ revenue impact, 432% growth achieved. Available for professional opportunities in Dallas, Fort Worth, Plano, Frisco, and surrounding DFW areas.',
+    'Revenue Operations Professional Richard Hudson specializes in sales automation, CRM optimization, and partnership program development across Dallas-Fort Worth metroplex. SalesLoft Admin Certified (Level 1 & 2) and HubSpot Revenue Operations Certified. $4.8M+ revenue impact, 432% growth achieved. Available for professional opportunities in Dallas, Fort Worth, Frisco, and surrounding DFW areas.',
   keywords: [
     'revenue operations professional',
     'revenue operations specialist',
     'RevOps professional',
     'Dallas RevOps professional',
     'Fort Worth RevOps professional',
-    'Plano RevOps professional',
     'Frisco RevOps professional',
     'DFW RevOps professional',
     'business optimization',
@@ -46,7 +45,7 @@ export const baseMetadata: Metadata = {
     siteName: 'Richard Hudson',
     title: 'Richard Hudson | Revenue Operations Professional',
     description:
-      'Revenue Operations Professional Richard Hudson specializes in sales automation, CRM optimization, and partnership program development across Dallas-Fort Worth metroplex. SalesLoft Admin Certified (Level 1 & 2) and HubSpot Revenue Operations Certified. $4.8M+ revenue impact, 432% growth achieved. Available for professional opportunities in Dallas, Fort Worth, Plano, Frisco, and surrounding DFW areas.',
+      'Revenue Operations Professional Richard Hudson specializes in sales automation, CRM optimization, and partnership program development across Dallas-Fort Worth metroplex. SalesLoft Admin Certified (Level 1 & 2) and HubSpot Revenue Operations Certified. $4.8M+ revenue impact, 432% growth achieved. Available for professional opportunities in Dallas, Fort Worth, Frisco, and surrounding DFW areas.',
     url: 'https://richardwhudsonjr.com',
     images: [
       {
@@ -62,7 +61,7 @@ export const baseMetadata: Metadata = {
     creator: '@hudsor01',
     title: 'Richard Hudson | Revenue Operations Professional',
     description:
-      'Revenue Operations Professional Richard Hudson specializes in sales automation, CRM optimization, and partnership program development across Dallas-Fort Worth metroplex. SalesLoft Admin Certified (Level 1 & 2) and HubSpot Revenue Operations Certified. $4.8M+ revenue impact, 432% growth achieved. Available for professional opportunities in Dallas, Fort Worth, Plano, Frisco, and surrounding DFW areas.',
+      'Revenue Operations Professional Richard Hudson specializes in sales automation, CRM optimization, and partnership program development across Dallas-Fort Worth metroplex. SalesLoft Admin Certified (Level 1 & 2) and HubSpot Revenue Operations Certified. $4.8M+ revenue impact, 432% growth achieved. Available for professional opportunities in Dallas, Fort Worth, Frisco, and surrounding DFW areas.',
     images: ['/images/richard.jpg'],
   },
   robots: {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,4 +1,7 @@
 import { MetadataRoute } from 'next'
+import { createContextLogger } from '@/lib/logger'
+
+const logger = createContextLogger('Sitemap')
 
 // Revalidate sitemap every hour to include new blog posts from n8n automation
 export const revalidate = 3600
@@ -96,8 +99,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'monthly' as const,
       priority: 0.7,
     }))
-  } catch {
-    // Database unavailable — return static pages only
+  } catch (error) {
+    // Sitemap degrades gracefully to static pages — surface as warn so we
+    // notice the regression without paging anyone.
+    logger.warn('Sitemap blog query failed; returning static pages only', {
+      error: error instanceof Error ? error.message : String(error),
+    })
     blogPages = []
   }
 

--- a/src/components/layout/home-page-content.tsx
+++ b/src/components/layout/home-page-content.tsx
@@ -210,7 +210,7 @@ export default function HomePageContent() {
                     <div>
                       <h2 className="text-2xl font-bold text-foreground">Richard Hudson</h2>
                       <p className="text-muted-foreground font-medium">Revenue Operations</p>
-                      <p className="text-sm text-muted-foreground mt-1">Plano, TX</p>
+                      <p className="text-sm text-muted-foreground mt-1">Dallas, TX</p>
                     </div>
                   </div>
 
@@ -437,7 +437,7 @@ export default function HomePageContent() {
               </div>
             </div>
             <p className="text-muted-foreground text-sm">
-              Based in Plano, TX • Open to remote opportunities
+              Based in Dallas, TX • Open to remote opportunities
             </p>
           </div>
         </div>

--- a/src/components/seo/json-ld/person-json-ld.tsx
+++ b/src/components/seo/json-ld/person-json-ld.tsx
@@ -21,10 +21,10 @@ export function PersonJsonLd({ nonce }: { nonce?: string | null }) {
     ],
     address: {
       '@type': 'PostalAddress',
-      streetAddress: 'Plano Business District',
-      addressLocality: 'Plano',
+      streetAddress: 'Dallas Business District',
+      addressLocality: 'Dallas',
       addressRegion: 'TX',
-      postalCode: '75023',
+      postalCode: '75201',
       addressCountry: 'US',
     },
     email: 'contact@richardwhudsonjr.com',

--- a/src/components/ui/loading-states.tsx
+++ b/src/components/ui/loading-states.tsx
@@ -3,8 +3,11 @@
 import * as React from 'react'
 import { Loader2, RefreshCw, AlertCircle, CheckCircle2, FileX, WifiOff } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { createContextLogger } from '@/lib/logger'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
+
+const logger = createContextLogger('LoadingStates')
 
 // ============================================================================
 // LOADING SPINNER COMPONENT
@@ -490,6 +493,14 @@ export function RefreshButton({
     setIsRefreshing(true)
     try {
       await onRefresh()
+    } catch (error) {
+      // onRefresh's type allows void or Promise<void>; rejections from
+      // arbitrary callers would otherwise become unhandled — bypassing the
+      // React tree entirely. Catch + log so Sentry sees them.
+      logger.error(
+        'RefreshButton onRefresh failed',
+        error instanceof Error ? error : new Error(String(error))
+      )
     } finally {
       setIsRefreshing(false)
     }

--- a/src/lib/__tests__/json-ld-schemas.test.ts
+++ b/src/lib/__tests__/json-ld-schemas.test.ts
@@ -26,10 +26,10 @@ function buildPersonJsonLd() {
     ],
     address: {
       '@type': 'PostalAddress',
-      streetAddress: 'Plano Business District',
-      addressLocality: 'Plano',
+      streetAddress: 'Dallas Business District',
+      addressLocality: 'Dallas',
       addressRegion: 'TX',
-      postalCode: '75023',
+      postalCode: '75201',
       addressCountry: 'US',
     },
     email: 'contact@richardwhudsonjr.com',

--- a/src/lib/csrf-protection.ts
+++ b/src/lib/csrf-protection.ts
@@ -1,5 +1,8 @@
 import { cookies } from 'next/headers'
 import crypto from 'crypto'
+import { createContextLogger } from '@/lib/logger'
+
+const logger = createContextLogger('CSRFProtection')
 
 const CSRF_TOKEN_LENGTH = 32
 const CSRF_TOKEN_NAME = '__csrf_token'
@@ -97,7 +100,12 @@ export async function csrfProtectionMiddleware(
         const tokenValue = formData.get('_csrf_token')
         requestToken = tokenValue ? String(tokenValue) : undefined
       }
-    } catch (_error) {
+    } catch (error) {
+      // CSRF body-parse failures are security-adjacent — surface as warn so
+      // they reach Sentry without raising exception-grouping severity.
+      logger.warn('CSRF body parse failed', {
+        error: error instanceof Error ? error.message : String(error),
+      })
       return {
         valid: false,
         error: 'Failed to parse request body for CSRF token',

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -155,6 +155,10 @@ export async function checkDBHealth() {
     await db.$queryRaw`SELECT 1`
     return { status: 'healthy', timestamp: new Date().toISOString() }
   } catch (error) {
+    logger.error(
+      'checkDBHealth probe failed',
+      error instanceof Error ? error : new Error(String(error))
+    )
     return {
       status: 'unhealthy',
       error: error instanceof Error ? error.message : 'Unknown error',

--- a/src/lib/safe-lazy.ts
+++ b/src/lib/safe-lazy.ts
@@ -1,0 +1,33 @@
+'use client'
+
+import type { ComponentType } from 'react'
+import { createContextLogger } from '@/lib/logger'
+
+const logger = createContextLogger('SafeLazy')
+
+type LazyImport<T> = Promise<{ default: ComponentType<T> }>
+
+/**
+ * Wraps a `next/dynamic` import with telemetry on chunk-load failure.
+ *
+ * Chunk failures (CDN miss, deploy race, network blip) are common in the wild
+ * and otherwise invisible — `dynamic(() => import(...).catch(() => Fallback))`
+ * silently swaps in the fallback with no Sentry signal. This helper preserves
+ * that fallback UX while routing the failure through `logger.warn` so it
+ * surfaces in Sentry as a captureMessage(warning) without raising
+ * exception-grouping severity.
+ */
+export function safeLazy<T>(
+  importFn: () => LazyImport<T>,
+  label: string,
+  Fallback: ComponentType<T>
+): () => LazyImport<T> {
+  return () =>
+    importFn().catch((error: unknown) => {
+      logger.warn('Chunk load failed', {
+        label,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return { default: Fallback }
+    })
+}

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -6,6 +6,7 @@
 import { db } from '@/lib/db'
 import { Prisma } from '@/generated/prisma/client'
 import { logger } from '@/lib/logger'
+import { escapeRegExp } from '@/lib/utils'
 
 export interface SearchResult {
   id: string
@@ -128,7 +129,10 @@ export function highlightSearchTerms(text: string, query: string): string {
   let highlighted = text
 
   for (const term of terms) {
-    const regex = new RegExp(`(${term})`, 'gi')
+    // Escape regex metacharacters — terms come from user query strings, so
+    // an unescaped `(`, `[`, `\`, `?`, etc. would throw SyntaxError and
+    // bubble up through highlightSearchTerms callers.
+    const regex = new RegExp(`(${escapeRegExp(term)})`, 'gi')
     highlighted = highlighted.replace(regex, '<mark>$1</mark>')
   }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -148,6 +148,15 @@ export function safeJsonParse<T>(json: string, schema: z.ZodSchema<T>, fallback:
   }
 }
 
+/**
+ * Escape regex metacharacters in a string so it can be embedded literally
+ * in a `new RegExp(...)` source. Required whenever the source is built from
+ * user input — otherwise an unescaped `(`, `[`, `\`, etc. throws SyntaxError.
+ */
+export function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 export function isInViewport(element: HTMLElement, offset = 0): boolean {
   if (isServer) return false
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -142,6 +142,8 @@ export function safeJsonParse<T>(json: string, schema: z.ZodSchema<T>, fallback:
     const parsed = JSON.parse(json)
     return schema.parse(parsed)
   } catch {
+    // Silent by contract — caller chose `fallback` precisely because they
+    // expect malformed input. Logging here would just create noise.
     return fallback
   }
 }

--- a/src/types/resume.ts
+++ b/src/types/resume.ts
@@ -50,7 +50,7 @@ export const resume: ResumeData = {
   title: 'Revenue Operations & Process Optimization Specialist',
   email: 'hello@richardwhudsonjr.com',
   phone: '',
-  location: 'Plano, Texas',
+  location: 'Dallas, Texas',
   summary:
     'Results-driven Revenue Operations Consultant with over 8 years of experience optimizing revenue processes and driving operational excellence. Expertise in implementing Salesforce and PartnerStack to enhance partner programs, boost efficiency, and increase profitability.',
 


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m [37mAudit found 6 HIGH-severity, 4 MEDIUM, and ~14 LOW/infra gaps where caught errors either swallowed silently or routed somewhere Sentry never sees. This PR closes them with one consistent pattern: `logger.error(label, errorObj, { context })` — which the existing `SentryTransport` in `src/lib/logger.ts` already routes to `captureException`.[0m
[38;5;8m   3[0m 
[38;5;8m   4[0m [37m## Why this was hidden[0m
[38;5;8m   5[0m 
[38;5;8m   6[0m [37m| Surface | Pre-PR behavior | Why Sentry didn't see it |[0m
[38;5;8m   7[0m [37m|---|---|---|[0m
[38;5;8m   8[0m [37m| `error.tsx` (segment boundary) | rendered fallback UI | error param was destructured as `_error` — never reported |[0m
[38;5;8m   9[0m [37m| Server action catch (`actions.ts`) | returned generic string | catch swallowed → `onRequestError` never fires |[0m
[38;5;8m  10[0m [37m| API route catch (`api/contact/route.ts`) | returned 500 | no logger call |[0m
[38;5;8m  11[0m [37m| RSC `cache()` catches in blog | returned `[]` / `null` | intentional build-phase swallow leaked to runtime |[0m
[38;5;8m  12[0m [37m| `next/dynamic` chunk-load failures | swapped in `ChartLoadError` fallback | `.catch(() => fallback)` had no telemetry |[0m
[38;5;8m  13[0m [37m| Sentry config | clean init | every `redirect()` and `notFound()` would have paged ops |[0m
[38;5;8m  14[0m 
[38;5;8m  15[0m [37m## Changes by severity[0m
[38;5;8m  16[0m 
[38;5;8m  17[0m [37m### HIGH (6)[0m
[38;5;8m  18[0m [37m- `src/app/error.tsx` — `useEffect(() => Sentry.captureException(error), [error])`, mirroring `global-error.tsx`. Highest-leverage fix.[0m
[38;5;8m  19[0m [37m- `src/app/contact/actions.ts` — wrapped with `Sentry.withServerActionInstrumentation` + `logger.error` in the non-Zod catch branch.[0m
[38;5;8m  20[0m [37m- `src/app/api/contact/route.ts` — `logger.error` before returning the generic 500.[0m
[38;5;8m  21[0m [37m- `src/app/blog/page.tsx` (×2 catches) and `src/app/blog/[slug]/page.tsx` — guard `NEXT_PHASE !== 'phase-production-build'` then `logger.error`. Slug query carries `{ slug }` context.[0m
[38;5;8m  22[0m 
[38;5;8m  23[0m [37m### MEDIUM (4)[0m
[38;5;8m  24[0m [37m- `src/app/sitemap.ts` — `logger.warn` instead of silent fallback.[0m
[38;5;8m  25[0m [37m- `src/app/blog/[slug]/page.tsx` `generateStaticParams` — same NEXT_PHASE guard.[0m
[38;5;8m  26[0m [37m- `src/lib/csrf-protection.ts` — `logger.warn` on body-parse failure (security-adjacent).[0m
[38;5;8m  27[0m [37m- `src/app/api/blog/[slug]/route.ts` view-count `.catch` — coerce err to Error, add `{ slug, postId }`.[0m
[38;5;8m  28[0m 
[38;5;8m  29[0m [37m### LOW + Infrastructure[0m
[38;5;8m  30[0m [37m- `src/lib/db.ts` `checkDBHealth` — log probe failure.[0m
[38;5;8m  31[0m [37m- `src/lib/utils.ts` `safeJsonParse` — comment the silent contract.[0m
[38;5;8m  32[0m [37m- `sentry.{server,client,edge}.config.ts` — `ignoreErrors` for `NEXT_REDIRECT` / `NEXT_NOT_FOUND` / `NEXT_HTTP_ERROR_FALLBACK` (all three configs); client also filters `ResizeObserver` / `AbortError`.[0m
[38;5;8m  33[0m [37m- **`src/lib/safe-lazy.ts` (new)** — `next/dynamic` wrapper that routes chunk failures through `logger.warn`. Applied to **11 chart code-split sites** under `src/app/projects/*` (CLV, deal-funnel, RevOps, lead-attribution, CAC unit economics).[0m
[38;5;8m  34[0m 
[38;5;8m  35[0m [37m## Pattern decisions documented in commit[0m
[38;5;8m  36[0m [37m- `logger.error` for real server failures (routes to `captureException` via SentryTransport).[0m
[38;5;8m  37[0m [37m- `logger.warn` for genuine warnings (rate-limit hits, CSRF parse, sitemap graceful-degrade) — keeps Sentry grouping separate from exceptions.[0m
[38;5;8m  38[0m [37m- Never double-report: logger handles Sentry routing; don't also call `captureException` on the same path.[0m
[38;5;8m  39[0m [37m- Server actions need `withServerActionInstrumentation` because `onRequestError` only catches *thrown* errors — caught-and-swallowed branches don't bubble.[0m
[38;5;8m  40[0m 
[38;5;8m  41[0m [37m## Test plan[0m
[38;5;8m  42[0m 
[38;5;8m  43[0m [37m- [x] `bun run lint` — clean[0m
[38;5;8m  44[0m [37m- [x] `bun run typecheck` — clean (TS 6.0.3)[0m
[38;5;8m  45[0m [37m- [x] `bunx vitest run` — 176/176 pass[0m
[38;5;8m  46[0m [37m- [ ] Manually trigger contact form failure (e.g., wrong RESEND_API_KEY) and confirm Sentry receives the exception[0m
[38;5;8m  47[0m [37m- [ ] Force a chart chunk 404 (block `_next/static/chunks/*Chart*.js` in devtools) and confirm `safe-lazy` warning appears in Sentry[0m
[38;5;8m  48[0m [37m- [ ] Confirm `redirect()`/`notFound()` calls don't show up as exceptions in Sentry after deploy[0m
[38;5;8m  49[0m 
[38;5;8m  50[0m [37m[hudsor01][0m