### PR TITLE
feat(seo): 2026-05 audit — 9 evidence-backed improvements

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { headers } from 'next/headers'
 import { notFound } from 'next/navigation'
 import { Navbar } from '@/components/layout/navbar'
 import { BlogPostLayout } from '../_components/blog-post-layout'
+import { RelatedPosts } from '@/components/blog/related-posts'
 import { BlogPostJsonLd } from '@/components/seo/blog-json-ld'
 import { BreadcrumbListJsonLd } from '@/components/seo/json-ld/breadcrumb-json-ld'
 import { transformToBlogPostData } from '@/lib/api-blog'
@@ -154,6 +155,12 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
 
           <div className="relative pt-24 pb-16 lg:pt-32 lg:pb-20">
             <BlogPostLayout post={post} />
+            <div className="max-w-4xl mx-auto px-6 lg:px-8">
+              <RelatedPosts
+                currentSlug={post.slug}
+                currentTags={post.tags?.map((t) => t.name) ?? []}
+              />
+            </div>
           </div>
         </main>
       </div>

--- a/src/app/blog/_components/blog-post-layout.tsx
+++ b/src/app/blog/_components/blog-post-layout.tsx
@@ -57,9 +57,14 @@ export function BlogPostLayout({ post }: PostLayoutProps) {
               {/* Category + Date */}
               <div className="flex flex-wrap items-center gap-3 text-body-sm text-muted-foreground">
                 {post.category && (
-                  <Badge variant="secondary" className="uppercase tracking-wide text-[0.7rem]">
-                    {post.category.name}
-                  </Badge>
+                  <Link
+                    href={`/blog/category/${post.category.slug}`}
+                    className="hover:opacity-80 transition-opacity"
+                  >
+                    <Badge variant="secondary" className="uppercase tracking-wide text-[0.7rem]">
+                      {post.category.name}
+                    </Badge>
+                  </Link>
                 )}
                 {publishedDate && (
                   <span className="inline-flex items-center gap-2">

--- a/src/app/blog/category/[slug]/page.tsx
+++ b/src/app/blog/category/[slug]/page.tsx
@@ -1,0 +1,234 @@
+import type { Metadata } from 'next'
+import { cache } from 'react'
+import { headers } from 'next/headers'
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import Image from 'next/image'
+import { Navbar } from '@/components/layout/navbar'
+import { BlogCategoryJsonLd } from '@/components/seo/blog-json-ld'
+import { BreadcrumbListJsonLd } from '@/components/seo/json-ld/breadcrumb-json-ld'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { db } from '@/lib/db'
+import { createContextLogger } from '@/lib/logger'
+
+const logger = createContextLogger('BlogCategoryPage')
+
+interface BlogCategoryPageProps {
+  params: Promise<{ slug: string }>
+}
+
+interface CategoryWithPosts {
+  id: string
+  name: string
+  slug: string
+  description: string | null
+  postCount: number
+  posts: Array<{
+    id: string
+    slug: string
+    title: string
+    excerpt: string | null
+    featuredImage: string | null
+    publishedAt: Date | null
+    tags: Array<{ tag: { id: string; name: string } }>
+  }>
+}
+
+const getCategoryWithPosts = cache(async (slug: string): Promise<CategoryWithPosts | null> => {
+  try {
+    const category = await db.category.findUnique({
+      where: { slug },
+      include: {
+        posts: {
+          where: { status: 'PUBLISHED', deletedAt: null },
+          orderBy: { publishedAt: 'desc' },
+          select: {
+            id: true,
+            slug: true,
+            title: true,
+            excerpt: true,
+            featuredImage: true,
+            publishedAt: true,
+            tags: { select: { tag: { select: { id: true, name: true } } } },
+          },
+        },
+      },
+    })
+    return category
+  } catch (error) {
+    if (process.env.NEXT_PHASE !== 'phase-production-build') {
+      logger.error(
+        'Blog category query failed',
+        error instanceof Error ? error : new Error(String(error)),
+        { slug }
+      )
+    }
+    return null
+  }
+})
+
+export async function generateMetadata({ params }: BlogCategoryPageProps): Promise<Metadata> {
+  const { slug } = await params
+  const category = await getCategoryWithPosts(slug)
+
+  if (!category) {
+    return {
+      title: 'Category Not Found',
+      description: 'The requested blog category could not be found.',
+      robots: { index: false, follow: false },
+    }
+  }
+
+  const title = `${category.name} — Articles | Richard Hudson`
+  const description =
+    category.description ||
+    `Articles about ${category.name} from Richard Hudson's revenue operations blog.`
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: `https://richardwhudsonjr.com/blog/category/${category.slug}`,
+      siteName: 'Richard Hudson',
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+    },
+    alternates: {
+      canonical: `https://richardwhudsonjr.com/blog/category/${category.slug}`,
+    },
+  }
+}
+
+function formatDate(value: Date | null): string {
+  if (!value) return ''
+  return new Date(value).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+export default async function BlogCategoryPage({ params }: BlogCategoryPageProps) {
+  const { slug } = await params
+  const category = await getCategoryWithPosts(slug)
+
+  if (!category) {
+    notFound()
+  }
+
+  const nonce = (await headers()).get('x-nonce')
+
+  return (
+    <>
+      <BlogCategoryJsonLd
+        nonce={nonce}
+        category={{
+          name: category.name,
+          slug: category.slug,
+          description: category.description ?? undefined,
+          postCount: category.postCount,
+        }}
+      />
+      <BreadcrumbListJsonLd
+        nonce={nonce}
+        items={[
+          { name: 'Home', url: 'https://richardwhudsonjr.com' },
+          { name: 'Blog', url: 'https://richardwhudsonjr.com/blog' },
+          {
+            name: category.name,
+            url: `https://richardwhudsonjr.com/blog/category/${category.slug}`,
+          },
+        ]}
+      />
+
+      <div className="min-h-screen bg-background">
+        <Navbar />
+        <main className="relative overflow-hidden">
+          <div className="absolute top-1/4 -right-32 w-64 h-64 bg-primary/5 rounded-full blur-3xl" />
+          <div className="absolute bottom-1/3 -left-32 w-64 h-64 bg-secondary/5 rounded-full blur-3xl" />
+
+          <div className="relative pt-24 pb-16 lg:pt-32 lg:pb-20">
+            <div className="max-w-7xl mx-auto px-6 lg:px-8">
+              <div className="mb-12">
+                <Link
+                  href="/blog"
+                  className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                >
+                  ← All articles
+                </Link>
+                <h1 className="font-display text-3xl md:text-4xl lg:text-5xl font-bold text-foreground mt-4 mb-4">
+                  {category.name}
+                </h1>
+                {category.description && (
+                  <p className="text-lg text-muted-foreground max-w-3xl">{category.description}</p>
+                )}
+                <p className="mt-4 text-sm text-muted-foreground">
+                  {category.posts.length} {category.posts.length === 1 ? 'article' : 'articles'}
+                </p>
+              </div>
+
+              {category.posts.length > 0 ? (
+                <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+                  {category.posts.map((post) => (
+                    <Link key={post.id} href={`/blog/${post.slug}`} className="group block h-full">
+                      <Card className="hover-lift hover:border-primary/50 transition-all h-full overflow-hidden">
+                        {post.featuredImage && (
+                          <div className="relative aspect-[16/10] overflow-hidden">
+                            <Image
+                              src={post.featuredImage}
+                              alt={post.title}
+                              fill
+                              className="object-cover transition-transform duration-300 ease-out group-hover:scale-105"
+                              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                            />
+                          </div>
+                        )}
+                        <CardHeader>
+                          {post.tags.length > 0 && (
+                            <div className="flex gap-2 mb-2 flex-wrap">
+                              {post.tags.slice(0, 3).map((pt) => (
+                                <Badge key={pt.tag.id} variant="secondary" className="text-xs">
+                                  {pt.tag.name}
+                                </Badge>
+                              ))}
+                            </div>
+                          )}
+                          <CardTitle className="text-xl line-clamp-2 group-hover:text-primary transition-colors">
+                            {post.title}
+                          </CardTitle>
+                          {post.excerpt && (
+                            <CardDescription className="line-clamp-3">
+                              {post.excerpt}
+                            </CardDescription>
+                          )}
+                        </CardHeader>
+                        <CardContent>
+                          <time className="text-sm text-muted-foreground">
+                            {formatDate(post.publishedAt)}
+                          </time>
+                        </CardContent>
+                      </Card>
+                    </Link>
+                  ))}
+                </div>
+              ) : (
+                <div className="py-16 text-center">
+                  <p className="text-muted-foreground">
+                    No articles published in this category yet.
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+        </main>
+      </div>
+    </>
+  )
+}

--- a/src/app/contact/contact-client.tsx
+++ b/src/app/contact/contact-client.tsx
@@ -30,9 +30,13 @@ export default function ContactPageClient() {
               <h1 className="font-display text-3xl md:text-4xl lg:text-5xl font-bold text-foreground mb-6">
                 Let's <span className="text-primary">Connect</span>
               </h1>
-              <p className="text-lg text-muted-foreground max-w-3xl mx-auto mb-8">
+              <p className="text-lg text-muted-foreground max-w-3xl mx-auto mb-4">
                 Open to new opportunities in Revenue Operations. Whether you're a recruiter, hiring
                 manager, or industry peer, I'd love to hear from you.
+              </p>
+              <p className="text-base text-muted-foreground max-w-3xl mx-auto mb-8">
+                Based in Dallas, serving Dallas, Fort Worth, Frisco, and the broader Dallas-Fort
+                Worth Metroplex — remote engagements welcome anywhere in the US.
               </p>
 
               {/* Quick Stats */}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -61,6 +61,11 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           href="/api/blog/rss"
         />
 
+        {/* IndieWeb identity verification (rel=me) — used by Mastodon, Bridgy, IndieAuth */}
+        <link rel="me" href="https://www.linkedin.com/in/hudsor01" />
+        <link rel="me" href="https://github.com/hudsor01" />
+        <link rel="me" href="https://twitter.com/hudsor01" />
+
         {/* Preconnect hints for performance */}
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />

--- a/src/app/projects/cac-unit-economics/_components/CACPageContent.tsx
+++ b/src/app/projects/cac-unit-economics/_components/CACPageContent.tsx
@@ -7,6 +7,7 @@ import { useQueryState } from 'nuqs'
 import { ProjectPageLayout } from '@/components/projects/project-page-layout'
 import { MetricsGrid } from '@/components/projects/metrics-grid'
 import { SectionCard } from '@/components/ui/section-card'
+import { ProjectJsonLd } from '@/components/seo/json-ld/project-json-ld'
 import { cacMetrics } from '../data/constants'
 import { formatCurrency } from '@/lib/data-formatters'
 import { OverviewTab } from './OverviewTab'
@@ -58,50 +59,61 @@ export default function CACUnitEconomics() {
   ]
 
   return (
-    <ProjectPageLayout
-      title="Customer Acquisition Cost Optimization & Unit Economics Dashboard"
-      description="Comprehensive CAC analysis and LTV:CAC ratio optimization that achieved 32% cost reduction through strategic partner channel optimization. Industry-benchmark 3.6:1 efficiency ratio with 8.4-month payback period across multi-tier SaaS products."
-      tags={[
-        { label: 'CAC Reduction: 32%', variant: 'primary' },
-        { label: 'LTV:CAC Ratio: 3.6:1', variant: 'secondary' },
-        { label: 'ROI Optimization', variant: 'primary' },
-        { label: 'Unit Economics', variant: 'secondary' },
-      ]}
-      showTimeframes={true}
-      timeframes={tabs.map((t) => t.charAt(0).toUpperCase() + t.slice(1))}
-      activeTimeframe={activeTab.charAt(0).toUpperCase() + activeTab.slice(1)}
-      onTimeframeChange={(timeframe) => setActiveTab(timeframe.toLowerCase() as Tab)}
-    >
-      {/* Key Metrics using standardized MetricsGrid */}
-      <MetricsGrid metrics={metrics} columns={4} className="mb-8" />
-
-      {/* Tab Content wrapped in SectionCard */}
-      <SectionCard
-        title="Analysis Details"
-        description="Detailed breakdown of CAC optimization across channels and products"
-        className="mb-8"
+    <>
+      <ProjectJsonLd
+        title="Customer Acquisition Cost Optimization & Unit Economics Dashboard"
+        description="Comprehensive CAC analysis and LTV:CAC ratio optimization that achieved 32% cost reduction through strategic partner channel optimization."
+        slug="cac-unit-economics"
+        category="Revenue Operations"
+        datePublished="2025-11-19"
+        dateModified="2026-05-06"
+        tags={['CAC', 'Unit Economics', 'LTV', 'SaaS Metrics', 'Revenue Operations']}
+      />
+      <ProjectPageLayout
+        title="Customer Acquisition Cost Optimization & Unit Economics Dashboard"
+        description="Comprehensive CAC analysis and LTV:CAC ratio optimization that achieved 32% cost reduction through strategic partner channel optimization. Industry-benchmark 3.6:1 efficiency ratio with 8.4-month payback period across multi-tier SaaS products."
+        tags={[
+          { label: 'CAC Reduction: 32%', variant: 'primary' },
+          { label: 'LTV:CAC Ratio: 3.6:1', variant: 'secondary' },
+          { label: 'ROI Optimization', variant: 'primary' },
+          { label: 'Unit Economics', variant: 'secondary' },
+        ]}
+        showTimeframes={true}
+        timeframes={tabs.map((t) => t.charAt(0).toUpperCase() + t.slice(1))}
+        activeTimeframe={activeTab.charAt(0).toUpperCase() + activeTab.slice(1)}
+        onTimeframeChange={(timeframe) => setActiveTab(timeframe.toLowerCase() as Tab)}
       >
-        {activeTab === 'overview' && <OverviewTab />}
-        {activeTab === 'channels' && <ChannelsTab />}
-        {activeTab === 'products' && <ProductsTab />}
-      </SectionCard>
+        {/* Key Metrics using standardized MetricsGrid */}
+        <MetricsGrid metrics={metrics} columns={4} className="mb-8" />
 
-      {/* Strategic Impact wrapped in SectionCard */}
-      <SectionCard
-        title="Strategic Impact"
-        description="Business impact and strategic outcomes from CAC optimization initiatives"
-        className="mb-8"
-      >
-        <StrategicImpact />
-      </SectionCard>
+        {/* Tab Content wrapped in SectionCard */}
+        <SectionCard
+          title="Analysis Details"
+          description="Detailed breakdown of CAC optimization across channels and products"
+          className="mb-8"
+        >
+          {activeTab === 'overview' && <OverviewTab />}
+          {activeTab === 'channels' && <ChannelsTab />}
+          {activeTab === 'products' && <ProductsTab />}
+        </SectionCard>
 
-      {/* Professional Narrative Sections wrapped in SectionCard */}
-      <SectionCard
-        title="Project Narrative"
-        description="Comprehensive case study following the STAR methodology"
-      >
-        <NarrativeSections />
-      </SectionCard>
-    </ProjectPageLayout>
+        {/* Strategic Impact wrapped in SectionCard */}
+        <SectionCard
+          title="Strategic Impact"
+          description="Business impact and strategic outcomes from CAC optimization initiatives"
+          className="mb-8"
+        >
+          <StrategicImpact />
+        </SectionCard>
+
+        {/* Professional Narrative Sections wrapped in SectionCard */}
+        <SectionCard
+          title="Project Narrative"
+          description="Comprehensive case study following the STAR methodology"
+        >
+          <NarrativeSections />
+        </SectionCard>
+      </ProjectPageLayout>
+    </>
   )
 }

--- a/src/app/projects/cac-unit-economics/page.tsx
+++ b/src/app/projects/cac-unit-economics/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import { headers } from 'next/headers'
+import { BreadcrumbListJsonLd } from '@/components/seo/json-ld/breadcrumb-json-ld'
 import CACPageContent from './_components/CACPageContent'
 
 export const dynamic = 'force-static'
@@ -40,6 +42,22 @@ export const metadata: Metadata = {
   },
 }
 
-export default function CACUnitEconomicsPage() {
-  return <CACPageContent />
+export default async function CACUnitEconomicsPage() {
+  const nonce = (await headers()).get('x-nonce')
+  return (
+    <>
+      <BreadcrumbListJsonLd
+        nonce={nonce}
+        items={[
+          { name: 'Home', url: 'https://richardwhudsonjr.com' },
+          { name: 'Projects', url: 'https://richardwhudsonjr.com/projects' },
+          {
+            name: 'CAC Optimization & Unit Economics',
+            url: 'https://richardwhudsonjr.com/projects/cac-unit-economics',
+          },
+        ]}
+      />
+      <CACPageContent />
+    </>
+  )
 }

--- a/src/app/projects/commission-optimization/_components/CommissionPageContent.tsx
+++ b/src/app/projects/commission-optimization/_components/CommissionPageContent.tsx
@@ -6,6 +6,7 @@ import { useQueryState } from 'nuqs'
 
 import { ProjectPageLayout } from '@/components/projects/project-page-layout'
 import { MetricsGrid } from '@/components/projects/metrics-grid'
+import { ProjectJsonLd } from '@/components/seo/json-ld/project-json-ld'
 import { commissionMetrics } from '../data/constants'
 import { formatCurrency, formatPercentage } from '@/lib/data-formatters'
 import { ProcessingMetrics } from './ProcessingMetrics'
@@ -59,46 +60,57 @@ export default function CommissionOptimization() {
   ]
 
   return (
-    <ProjectPageLayout
-      title="Commission & Incentive Optimization System"
-      description="Advanced commission management and partner incentive optimization platform managing $254K+ commission structures. Automated tier adjustments with 23% average commission rate optimization and ROI-driven compensation strategy delivering 34% performance improvement and 87.5% automation efficiency."
-      tags={[
-        {
-          label: `Commission Pool: ${formatCurrency(commissionMetrics.totalCommissionPool)}`,
-          variant: 'primary',
-        },
-        {
-          label: `Avg Rate: ${formatPercentage(commissionMetrics.averageCommissionRate / 100)}`,
-          variant: 'secondary',
-        },
-        {
-          label: `Performance: +${formatPercentage(commissionMetrics.performanceImprovement / 100)}`,
-          variant: 'primary',
-        },
-        {
-          label: `Automation: ${formatPercentage(commissionMetrics.automationEfficiency / 100)}`,
-          variant: 'secondary',
-        },
-      ]}
-      showTimeframes={true}
-      timeframes={tabs.map((t) => t.charAt(0).toUpperCase() + t.slice(1))}
-      activeTimeframe={activeTab.charAt(0).toUpperCase() + activeTab.slice(1)}
-      onTimeframeChange={(timeframe) => setActiveTab(timeframe.toLowerCase() as Tab)}
-    >
-      {/* Standardized Key Metrics Grid */}
-      <MetricsGrid metrics={metrics} columns={4} className="mb-8" />
+    <>
+      <ProjectJsonLd
+        title="Commission & Incentive Optimization System"
+        description="Advanced commission management and partner incentive optimization platform managing $254K+ commission structures with 34% performance improvement and 87.5% automation efficiency."
+        slug="commission-optimization"
+        category="Revenue Operations"
+        datePublished="2025-11-19"
+        dateModified="2026-05-06"
+        tags={['Commission Management', 'Partner Incentives', 'Compensation', 'Sales Operations']}
+      />
+      <ProjectPageLayout
+        title="Commission & Incentive Optimization System"
+        description="Advanced commission management and partner incentive optimization platform managing $254K+ commission structures. Automated tier adjustments with 23% average commission rate optimization and ROI-driven compensation strategy delivering 34% performance improvement and 87.5% automation efficiency."
+        tags={[
+          {
+            label: `Commission Pool: ${formatCurrency(commissionMetrics.totalCommissionPool)}`,
+            variant: 'primary',
+          },
+          {
+            label: `Avg Rate: ${formatPercentage(commissionMetrics.averageCommissionRate / 100)}`,
+            variant: 'secondary',
+          },
+          {
+            label: `Performance: +${formatPercentage(commissionMetrics.performanceImprovement / 100)}`,
+            variant: 'primary',
+          },
+          {
+            label: `Automation: ${formatPercentage(commissionMetrics.automationEfficiency / 100)}`,
+            variant: 'secondary',
+          },
+        ]}
+        showTimeframes={true}
+        timeframes={tabs.map((t) => t.charAt(0).toUpperCase() + t.slice(1))}
+        activeTimeframe={activeTab.charAt(0).toUpperCase() + activeTab.slice(1)}
+        onTimeframeChange={(timeframe) => setActiveTab(timeframe.toLowerCase() as Tab)}
+      >
+        {/* Standardized Key Metrics Grid */}
+        <MetricsGrid metrics={metrics} columns={4} className="mb-8" />
 
-      {/* Processing Metrics */}
-      <ProcessingMetrics />
+        {/* Processing Metrics */}
+        <ProcessingMetrics />
 
-      {/* Tab Content */}
-      {activeTab === 'overview' && <OverviewTab />}
-      {activeTab === 'tiers' && <TiersTab />}
-      {activeTab === 'incentives' && <IncentivesTab />}
-      {activeTab === 'automation' && <AutomationTab />}
+        {/* Tab Content */}
+        {activeTab === 'overview' && <OverviewTab />}
+        {activeTab === 'tiers' && <TiersTab />}
+        {activeTab === 'incentives' && <IncentivesTab />}
+        {activeTab === 'automation' && <AutomationTab />}
 
-      {/* Professional Narrative Sections */}
-      <NarrativeSections />
-    </ProjectPageLayout>
+        {/* Professional Narrative Sections */}
+        <NarrativeSections />
+      </ProjectPageLayout>
+    </>
   )
 }

--- a/src/app/projects/commission-optimization/page.tsx
+++ b/src/app/projects/commission-optimization/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import { headers } from 'next/headers'
+import { BreadcrumbListJsonLd } from '@/components/seo/json-ld/breadcrumb-json-ld'
 import CommissionPageContent from './_components/CommissionPageContent'
 
 export const dynamic = 'force-static'
@@ -40,6 +42,22 @@ export const metadata: Metadata = {
   },
 }
 
-export default function CommissionOptimizationPage() {
-  return <CommissionPageContent />
+export default async function CommissionOptimizationPage() {
+  const nonce = (await headers()).get('x-nonce')
+  return (
+    <>
+      <BreadcrumbListJsonLd
+        nonce={nonce}
+        items={[
+          { name: 'Home', url: 'https://richardwhudsonjr.com' },
+          { name: 'Projects', url: 'https://richardwhudsonjr.com/projects' },
+          {
+            name: 'Commission & Incentive Optimization',
+            url: 'https://richardwhudsonjr.com/projects/commission-optimization',
+          },
+        ]}
+      />
+      <CommissionPageContent />
+    </>
+  )
 }

--- a/src/app/projects/customer-lifetime-value/_components/CLVPageContent.tsx
+++ b/src/app/projects/customer-lifetime-value/_components/CLVPageContent.tsx
@@ -7,6 +7,7 @@ import { useQueryState } from 'nuqs'
 import { ProjectPageLayout } from '@/components/projects/project-page-layout'
 import { MetricsGrid } from '@/components/projects/metrics-grid'
 import { SectionCard } from '@/components/ui/section-card'
+import { ProjectJsonLd } from '@/components/seo/json-ld/project-json-ld'
 import { formatCurrency, formatNumber, formatPercentage } from '@/lib/data-formatters'
 import { clvMetrics } from '../data/constants'
 import { OverviewTab } from './OverviewTab'
@@ -58,56 +59,67 @@ export default function CustomerLifetimeValueAnalytics() {
   ]
 
   return (
-    <ProjectPageLayout
-      title="Customer Lifetime Value Predictive Analytics Dashboard"
-      description="Advanced CLV analytics platform leveraging BTYD (Buy Till You Die) predictive modeling framework. Achieving 94.3% prediction accuracy through machine learning algorithms and real-time customer behavior tracking across 5 distinct customer segments."
-      tags={[
-        {
-          label: `Prediction Accuracy: ${formatPercentage(clvMetrics.predictionAccuracy / 100)}`,
-          variant: 'primary',
-        },
-        {
-          label: `Avg CLV: ${formatCurrency(clvMetrics.averageCLV, { compact: true })}`,
-          variant: 'secondary',
-        },
-        { label: 'Machine Learning', variant: 'primary' },
-        { label: 'BTYD Framework', variant: 'secondary' },
-      ]}
-      showTimeframes={true}
-      timeframes={tabs.map((t) => t.charAt(0).toUpperCase() + t.slice(1))}
-      activeTimeframe={activeTab.charAt(0).toUpperCase() + activeTab.slice(1)}
-      onTimeframeChange={(timeframe) => setActiveTab(timeframe.toLowerCase() as Tab)}
-    >
-      {/* Key Metrics using standardized MetricsGrid */}
-      <MetricsGrid metrics={metrics} columns={4} className="mb-8" />
-
-      {/* Tab Content wrapped in SectionCard */}
-      <SectionCard
-        title="CLV Analytics"
-        description="Comprehensive customer lifetime value analysis and insights"
-        className="mb-8"
+    <>
+      <ProjectJsonLd
+        title="Customer Lifetime Value Predictive Analytics Dashboard"
+        description="Advanced CLV analytics platform leveraging BTYD (Buy Till You Die) predictive modeling, achieving 94.3% prediction accuracy through machine learning across 5 customer segments."
+        slug="customer-lifetime-value"
+        category="Predictive Analytics"
+        datePublished="2025-11-19"
+        dateModified="2026-05-06"
+        tags={['CLV', 'Predictive Analytics', 'BTYD', 'Machine Learning', 'Customer Segments']}
+      />
+      <ProjectPageLayout
+        title="Customer Lifetime Value Predictive Analytics Dashboard"
+        description="Advanced CLV analytics platform leveraging BTYD (Buy Till You Die) predictive modeling framework. Achieving 94.3% prediction accuracy through machine learning algorithms and real-time customer behavior tracking across 5 distinct customer segments."
+        tags={[
+          {
+            label: `Prediction Accuracy: ${formatPercentage(clvMetrics.predictionAccuracy / 100)}`,
+            variant: 'primary',
+          },
+          {
+            label: `Avg CLV: ${formatCurrency(clvMetrics.averageCLV, { compact: true })}`,
+            variant: 'secondary',
+          },
+          { label: 'Machine Learning', variant: 'primary' },
+          { label: 'BTYD Framework', variant: 'secondary' },
+        ]}
+        showTimeframes={true}
+        timeframes={tabs.map((t) => t.charAt(0).toUpperCase() + t.slice(1))}
+        activeTimeframe={activeTab.charAt(0).toUpperCase() + activeTab.slice(1)}
+        onTimeframeChange={(timeframe) => setActiveTab(timeframe.toLowerCase() as Tab)}
       >
-        {activeTab === 'overview' && <OverviewTab />}
-        {activeTab === 'segments' && <SegmentsTab />}
-        {activeTab === 'predictions' && <PredictionsTab />}
-      </SectionCard>
+        {/* Key Metrics using standardized MetricsGrid */}
+        <MetricsGrid metrics={metrics} columns={4} className="mb-8" />
 
-      {/* Strategic Impact wrapped in SectionCard */}
-      <SectionCard
-        title="Strategic Impact"
-        description="Business impact and strategic outcomes from CLV optimization"
-        className="mb-8"
-      >
-        <StrategicImpact />
-      </SectionCard>
+        {/* Tab Content wrapped in SectionCard */}
+        <SectionCard
+          title="CLV Analytics"
+          description="Comprehensive customer lifetime value analysis and insights"
+          className="mb-8"
+        >
+          {activeTab === 'overview' && <OverviewTab />}
+          {activeTab === 'segments' && <SegmentsTab />}
+          {activeTab === 'predictions' && <PredictionsTab />}
+        </SectionCard>
 
-      {/* Professional Narrative Sections wrapped in SectionCard */}
-      <SectionCard
-        title="Project Narrative"
-        description="Comprehensive case study following the STAR methodology"
-      >
-        <NarrativeSections />
-      </SectionCard>
-    </ProjectPageLayout>
+        {/* Strategic Impact wrapped in SectionCard */}
+        <SectionCard
+          title="Strategic Impact"
+          description="Business impact and strategic outcomes from CLV optimization"
+          className="mb-8"
+        >
+          <StrategicImpact />
+        </SectionCard>
+
+        {/* Professional Narrative Sections wrapped in SectionCard */}
+        <SectionCard
+          title="Project Narrative"
+          description="Comprehensive case study following the STAR methodology"
+        >
+          <NarrativeSections />
+        </SectionCard>
+      </ProjectPageLayout>
+    </>
   )
 }

--- a/src/app/projects/customer-lifetime-value/page.tsx
+++ b/src/app/projects/customer-lifetime-value/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import { headers } from 'next/headers'
+import { BreadcrumbListJsonLd } from '@/components/seo/json-ld/breadcrumb-json-ld'
 import CLVPageContent from './_components/CLVPageContent'
 
 export const dynamic = 'force-static'
@@ -40,6 +42,22 @@ export const metadata: Metadata = {
   },
 }
 
-export default function CustomerLifetimeValuePage() {
-  return <CLVPageContent />
+export default async function CustomerLifetimeValuePage() {
+  const nonce = (await headers()).get('x-nonce')
+  return (
+    <>
+      <BreadcrumbListJsonLd
+        nonce={nonce}
+        items={[
+          { name: 'Home', url: 'https://richardwhudsonjr.com' },
+          { name: 'Projects', url: 'https://richardwhudsonjr.com/projects' },
+          {
+            name: 'Customer Lifetime Value Analytics',
+            url: 'https://richardwhudsonjr.com/projects/customer-lifetime-value',
+          },
+        ]}
+      />
+      <CLVPageContent />
+    </>
+  )
 }

--- a/src/app/projects/multi-channel-attribution/_components/MultiChannelPageContent.tsx
+++ b/src/app/projects/multi-channel-attribution/_components/MultiChannelPageContent.tsx
@@ -7,6 +7,7 @@ import { useQueryState } from 'nuqs'
 import { ProjectPageLayout } from '@/components/projects/project-page-layout'
 import { MetricsGrid } from '@/components/projects/metrics-grid'
 import { SectionCard } from '@/components/ui/section-card'
+import { ProjectJsonLd } from '@/components/seo/json-ld/project-json-ld'
 import { formatCurrency, formatNumber } from '@/lib/data-formatters'
 import { attributionMetrics } from '../data/constants'
 import { formatPercent } from '../utils'
@@ -65,57 +66,68 @@ export default function MultiChannelAttribution() {
   ]
 
   return (
-    <ProjectPageLayout
-      title="Multi-Channel Attribution Analytics Dashboard"
-      description="Advanced marketing attribution analytics platform using machine learning models to track customer journeys across 12+ touchpoints. Delivering 92.4% attribution accuracy and $2.3M ROI optimization through data-driven attribution modeling and cross-channel insights."
-      tags={[
-        {
-          label: `Attribution Accuracy: ${formatPercent(attributionMetrics.attributionAccuracy)}`,
-          variant: 'primary',
-        },
-        {
-          label: `ROI Optimization: ${formatCurrency(attributionMetrics.totalROI, { compact: true })}`,
-          variant: 'secondary',
-        },
-        { label: 'ML Attribution Models', variant: 'primary' },
-        { label: 'Customer Journey Analytics', variant: 'secondary' },
-      ]}
-      showTimeframes={true}
-      timeframes={tabs.map((t) => t.charAt(0).toUpperCase() + t.slice(1))}
-      activeTimeframe={activeTab.charAt(0).toUpperCase() + activeTab.slice(1)}
-      onTimeframeChange={(timeframe) => setActiveTab(timeframe.toLowerCase() as Tab)}
-    >
-      {/* Key Metrics using standardized MetricsGrid */}
-      <MetricsGrid metrics={metrics} columns={4} className="mb-8" />
-
-      {/* Tab Content wrapped in SectionCard */}
-      <SectionCard
-        title="Attribution Analysis"
-        description="Detailed multi-channel attribution analysis and insights"
-        className="mb-8"
+    <>
+      <ProjectJsonLd
+        title="Multi-Channel Attribution Analytics Dashboard"
+        description="ML-powered marketing attribution analytics tracking customer journeys across 12+ touchpoints with 92.4% attribution accuracy and $2.3M ROI optimization."
+        slug="multi-channel-attribution"
+        category="Marketing Analytics"
+        datePublished="2025-11-19"
+        dateModified="2026-05-06"
+        tags={['Multi-Touch Attribution', 'Marketing Analytics', 'ML Models', 'Customer Journey']}
+      />
+      <ProjectPageLayout
+        title="Multi-Channel Attribution Analytics Dashboard"
+        description="Advanced marketing attribution analytics platform using machine learning models to track customer journeys across 12+ touchpoints. Delivering 92.4% attribution accuracy and $2.3M ROI optimization through data-driven attribution modeling and cross-channel insights."
+        tags={[
+          {
+            label: `Attribution Accuracy: ${formatPercent(attributionMetrics.attributionAccuracy)}`,
+            variant: 'primary',
+          },
+          {
+            label: `ROI Optimization: ${formatCurrency(attributionMetrics.totalROI, { compact: true })}`,
+            variant: 'secondary',
+          },
+          { label: 'ML Attribution Models', variant: 'primary' },
+          { label: 'Customer Journey Analytics', variant: 'secondary' },
+        ]}
+        showTimeframes={true}
+        timeframes={tabs.map((t) => t.charAt(0).toUpperCase() + t.slice(1))}
+        activeTimeframe={activeTab.charAt(0).toUpperCase() + activeTab.slice(1)}
+        onTimeframeChange={(timeframe) => setActiveTab(timeframe.toLowerCase() as Tab)}
       >
-        {activeTab === 'overview' && <OverviewTab />}
-        {activeTab === 'models' && <ModelsTab />}
-        {activeTab === 'journeys' && <JourneysTab />}
-        {activeTab === 'channels' && <ChannelsTab />}
-      </SectionCard>
+        {/* Key Metrics using standardized MetricsGrid */}
+        <MetricsGrid metrics={metrics} columns={4} className="mb-8" />
 
-      {/* Strategic Impact wrapped in SectionCard */}
-      <SectionCard
-        title="Strategic Impact"
-        description="Business impact and strategic outcomes from attribution optimization"
-        className="mb-8"
-      >
-        <StrategicImpact />
-      </SectionCard>
+        {/* Tab Content wrapped in SectionCard */}
+        <SectionCard
+          title="Attribution Analysis"
+          description="Detailed multi-channel attribution analysis and insights"
+          className="mb-8"
+        >
+          {activeTab === 'overview' && <OverviewTab />}
+          {activeTab === 'models' && <ModelsTab />}
+          {activeTab === 'journeys' && <JourneysTab />}
+          {activeTab === 'channels' && <ChannelsTab />}
+        </SectionCard>
 
-      {/* Professional Narrative Sections wrapped in SectionCard */}
-      <SectionCard
-        title="Project Narrative"
-        description="Comprehensive case study following the STAR methodology"
-      >
-        <NarrativeSections />
-      </SectionCard>
-    </ProjectPageLayout>
+        {/* Strategic Impact wrapped in SectionCard */}
+        <SectionCard
+          title="Strategic Impact"
+          description="Business impact and strategic outcomes from attribution optimization"
+          className="mb-8"
+        >
+          <StrategicImpact />
+        </SectionCard>
+
+        {/* Professional Narrative Sections wrapped in SectionCard */}
+        <SectionCard
+          title="Project Narrative"
+          description="Comprehensive case study following the STAR methodology"
+        >
+          <NarrativeSections />
+        </SectionCard>
+      </ProjectPageLayout>
+    </>
   )
 }

--- a/src/app/projects/multi-channel-attribution/page.tsx
+++ b/src/app/projects/multi-channel-attribution/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import { headers } from 'next/headers'
+import { BreadcrumbListJsonLd } from '@/components/seo/json-ld/breadcrumb-json-ld'
 import MultiChannelPageContent from './_components/MultiChannelPageContent'
 
 export const dynamic = 'force-static'
@@ -40,6 +42,22 @@ export const metadata: Metadata = {
   },
 }
 
-export default function MultiChannelAttributionPage() {
-  return <MultiChannelPageContent />
+export default async function MultiChannelAttributionPage() {
+  const nonce = (await headers()).get('x-nonce')
+  return (
+    <>
+      <BreadcrumbListJsonLd
+        nonce={nonce}
+        items={[
+          { name: 'Home', url: 'https://richardwhudsonjr.com' },
+          { name: 'Projects', url: 'https://richardwhudsonjr.com/projects' },
+          {
+            name: 'Multi-Channel Attribution Analytics',
+            url: 'https://richardwhudsonjr.com/projects/multi-channel-attribution',
+          },
+        ]}
+      />
+      <MultiChannelPageContent />
+    </>
+  )
 }

--- a/src/app/projects/partner-performance/_components/PartnerPerformancePageContent.tsx
+++ b/src/app/projects/partner-performance/_components/PartnerPerformancePageContent.tsx
@@ -7,6 +7,7 @@ import { useQueryState } from 'nuqs'
 import { ProjectPageLayout } from '@/components/projects/project-page-layout'
 import { MetricsGrid } from '@/components/projects/metrics-grid'
 import { SectionCard } from '@/components/ui/section-card'
+import { ProjectJsonLd } from '@/components/seo/json-ld/project-json-ld'
 import { formatCurrency, formatNumber, formatPercentage } from '@/lib/data-formatters'
 import { NarrativeSections } from './NarrativeSections'
 import { OverviewTab } from './OverviewTab'
@@ -67,45 +68,59 @@ export default function PartnerPerformanceIntelligence() {
   ]
 
   return (
-    <ProjectPageLayout
-      title="Partner Performance Intelligence Dashboard"
-      description="Strategic channel analytics and partner ROI intelligence demonstrating 83.2% win rate across multi-tier partner ecosystem. Real-time performance tracking following industry-standard 80/20 partner revenue distribution."
-      tags={[
-        { label: `Channel ROI: ${partnerMetrics.quickRatio}x`, variant: 'primary' },
-        {
-          label: `Win Rate: ${formatPercentage(partnerMetrics.winRate / 100)}`,
-          variant: 'secondary',
-        },
-        { label: 'Partner Intelligence', variant: 'primary' },
-        { label: 'Revenue Operations', variant: 'secondary' },
-      ]}
-      showTimeframes={true}
-      timeframes={tabs.map((t) => t.charAt(0).toUpperCase() + t.slice(1).replace('-', ' '))}
-      activeTimeframe={activeTab.charAt(0).toUpperCase() + activeTab.slice(1).replace('-', ' ')}
-      onTimeframeChange={(timeframe) => {
-        const tab = timeframe.toLowerCase().replace(' ', '-') as Tab
-        setActiveTab(tab)
-      }}
-    >
-      {/* Key Metrics using standardized MetricsGrid */}
-      <MetricsGrid metrics={metrics} columns={4} className="mb-8" />
-
-      {/* Tab Content wrapped in SectionCard */}
-      <SectionCard
-        title="Partner Performance Analysis"
-        description="Comprehensive partner analytics and performance insights"
-        className="mb-8"
+    <>
+      <ProjectJsonLd
+        title="Partner Performance Intelligence Dashboard"
+        description="Strategic channel analytics and partner ROI intelligence demonstrating 83.2% win rate across multi-tier partner ecosystem with 4.7x quick ratio."
+        slug="partner-performance"
+        category="Revenue Operations"
+        datePublished="2025-11-19"
+        dateModified="2026-05-06"
+        tags={['Partner Analytics', 'Channel Strategy', 'Revenue Operations', 'SaaS Metrics']}
+      />
+      <ProjectPageLayout
+        title="Partner Performance Intelligence Dashboard"
+        description="Strategic channel analytics and partner ROI intelligence demonstrating 83.2% win rate across multi-tier partner ecosystem. Real-time performance tracking following industry-standard 80/20 partner revenue distribution."
+        tags={[
+          { label: `Channel ROI: ${partnerMetrics.quickRatio}x`, variant: 'primary' },
+          {
+            label: `Win Rate: ${formatPercentage(partnerMetrics.winRate / 100)}`,
+            variant: 'secondary',
+          },
+          { label: 'Partner Intelligence', variant: 'primary' },
+          { label: 'Revenue Operations', variant: 'secondary' },
+        ]}
+        showTimeframes={true}
+        timeframes={tabs.map((t) => t.charAt(0).toUpperCase() + t.slice(1).replace('-', ' '))}
+        activeTimeframe={activeTab.charAt(0).toUpperCase() + activeTab.slice(1).replace('-', ' ')}
+        onTimeframeChange={(timeframe) => {
+          const tab = timeframe.toLowerCase().replace(' ', '-') as Tab
+          setActiveTab(tab)
+        }}
       >
-        {activeTab === 'overview' && <OverviewTab />}
-        {activeTab === 'tiers' && <TiersTab />}
-        {activeTab === 'top-performers' && <TopPerformersTab />}
-      </SectionCard>
+        {/* Key Metrics using standardized MetricsGrid */}
+        <MetricsGrid metrics={metrics} columns={4} className="mb-8" />
 
-      {/* Strategic Insights */}
-      <StrategicInsights winRate={partnerMetrics.winRate} quickRatio={partnerMetrics.quickRatio} />
+        {/* Tab Content wrapped in SectionCard */}
+        <SectionCard
+          title="Partner Performance Analysis"
+          description="Comprehensive partner analytics and performance insights"
+          className="mb-8"
+        >
+          {activeTab === 'overview' && <OverviewTab />}
+          {activeTab === 'tiers' && <TiersTab />}
+          {activeTab === 'top-performers' && <TopPerformersTab />}
+        </SectionCard>
 
-      {/* Professional Narrative Sections - STAR Method */}
-      <NarrativeSections />
-    </ProjectPageLayout>
+        {/* Strategic Insights */}
+        <StrategicInsights
+          winRate={partnerMetrics.winRate}
+          quickRatio={partnerMetrics.quickRatio}
+        />
+
+        {/* Professional Narrative Sections - STAR Method */}
+        <NarrativeSections />
+      </ProjectPageLayout>
+    </>
   )
 }

--- a/src/app/projects/partner-performance/page.tsx
+++ b/src/app/projects/partner-performance/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import { headers } from 'next/headers'
+import { BreadcrumbListJsonLd } from '@/components/seo/json-ld/breadcrumb-json-ld'
 import PartnerPerformancePageContent from './_components/PartnerPerformancePageContent'
 
 export const dynamic = 'force-static'
@@ -40,6 +42,22 @@ export const metadata: Metadata = {
   },
 }
 
-export default function PartnerPerformancePage() {
-  return <PartnerPerformancePageContent />
+export default async function PartnerPerformancePage() {
+  const nonce = (await headers()).get('x-nonce')
+  return (
+    <>
+      <BreadcrumbListJsonLd
+        nonce={nonce}
+        items={[
+          { name: 'Home', url: 'https://richardwhudsonjr.com' },
+          { name: 'Projects', url: 'https://richardwhudsonjr.com/projects' },
+          {
+            name: 'Partner Performance Intelligence',
+            url: 'https://richardwhudsonjr.com/projects/partner-performance',
+          },
+        ]}
+      />
+      <PartnerPerformancePageContent />
+    </>
+  )
 }

--- a/src/app/projects/revenue-operations-center/_components/RevenueOpsCenterPageContent.tsx
+++ b/src/app/projects/revenue-operations-center/_components/RevenueOpsCenterPageContent.tsx
@@ -9,6 +9,7 @@ import { ProjectPageLayout } from '@/components/projects/project-page-layout'
 import { revenueMetrics } from '../data/constants'
 import { formatCurrency, formatPercent } from '../utils'
 import { MetricsGrid } from '@/components/projects/metrics-grid'
+import { ProjectJsonLd } from '@/components/seo/json-ld/project-json-ld'
 import { KPIAlerts } from './KPIAlerts'
 import { StrategicImpact } from './StrategicImpact'
 import { NarrativeSections } from './NarrativeSections'
@@ -107,39 +108,50 @@ export default function RevenueOperationsCenter() {
   )
 
   return (
-    <ProjectPageLayout
-      title="Revenue Operations Command Center"
-      description="Comprehensive revenue operations dashboard consolidating pipeline health, forecasting accuracy, partner performance, and operational KPIs. Real-time insights with 96.8% forecast accuracy and 89.7% operational efficiency across sales, marketing, and partner channels."
-      tags={[
-        { label: 'Forecast Accuracy: 96.8%', variant: 'primary' },
-        { label: 'Pipeline Health: 92.4%', variant: 'secondary' },
-        { label: 'Revenue Growth: +34.2%', variant: 'primary' },
-        { label: 'Operations Dashboard', variant: 'secondary' },
-      ]}
-      showTimeframes={true}
-      timeframes={tabs.map((t) => t.charAt(0).toUpperCase() + t.slice(1))}
-      activeTimeframe={activeTab.charAt(0).toUpperCase() + activeTab.slice(1)}
-      onTimeframeChange={(timeframe) => setActiveTab(timeframe.toLowerCase() as Tab)}
-    >
-      {/* Key Metrics using standardized MetricsGrid */}
-      <MetricsGrid metrics={metrics} columns={4} className="mb-12" />
+    <>
+      <ProjectJsonLd
+        title="Revenue Operations Command Center"
+        description="Comprehensive revenue operations dashboard consolidating pipeline health, forecasting, partner performance, and operational KPIs with 96.8% forecast accuracy and 89.7% operational efficiency."
+        slug="revenue-operations-center"
+        category="Revenue Operations"
+        datePublished="2025-11-19"
+        dateModified="2026-05-06"
+        tags={['RevOps', 'Pipeline Health', 'Forecasting', 'Operations Dashboard']}
+      />
+      <ProjectPageLayout
+        title="Revenue Operations Command Center"
+        description="Comprehensive revenue operations dashboard consolidating pipeline health, forecasting accuracy, partner performance, and operational KPIs. Real-time insights with 96.8% forecast accuracy and 89.7% operational efficiency across sales, marketing, and partner channels."
+        tags={[
+          { label: 'Forecast Accuracy: 96.8%', variant: 'primary' },
+          { label: 'Pipeline Health: 92.4%', variant: 'secondary' },
+          { label: 'Revenue Growth: +34.2%', variant: 'primary' },
+          { label: 'Operations Dashboard', variant: 'secondary' },
+        ]}
+        showTimeframes={true}
+        timeframes={tabs.map((t) => t.charAt(0).toUpperCase() + t.slice(1))}
+        activeTimeframe={activeTab.charAt(0).toUpperCase() + activeTab.slice(1)}
+        onTimeframeChange={(timeframe) => setActiveTab(timeframe.toLowerCase() as Tab)}
+      >
+        {/* Key Metrics using standardized MetricsGrid */}
+        <MetricsGrid metrics={metrics} columns={4} className="mb-12" />
 
-      {/* KPI Alerts */}
-      <KPIAlerts />
+        {/* KPI Alerts */}
+        <KPIAlerts />
 
-      {/* Tab Content with Suspense */}
-      <Suspense fallback={<TabSkeleton />}>
-        {activeTab === 'overview' && <OverviewTab />}
-        {activeTab === 'pipeline' && <PipelineTab />}
-        {activeTab === 'forecasting' && <ForecastingTab />}
-        {activeTab === 'operations' && <OperationsTab />}
-      </Suspense>
+        {/* Tab Content with Suspense */}
+        <Suspense fallback={<TabSkeleton />}>
+          {activeTab === 'overview' && <OverviewTab />}
+          {activeTab === 'pipeline' && <PipelineTab />}
+          {activeTab === 'forecasting' && <ForecastingTab />}
+          {activeTab === 'operations' && <OperationsTab />}
+        </Suspense>
 
-      {/* Strategic Impact */}
-      <StrategicImpact />
+        {/* Strategic Impact */}
+        <StrategicImpact />
 
-      {/* Professional Narrative Sections */}
-      <NarrativeSections />
-    </ProjectPageLayout>
+        {/* Professional Narrative Sections */}
+        <NarrativeSections />
+      </ProjectPageLayout>
+    </>
   )
 }

--- a/src/app/projects/revenue-operations-center/page.tsx
+++ b/src/app/projects/revenue-operations-center/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import { headers } from 'next/headers'
+import { BreadcrumbListJsonLd } from '@/components/seo/json-ld/breadcrumb-json-ld'
 import RevenueOpsCenterPageContent from './_components/RevenueOpsCenterPageContent'
 
 export const dynamic = 'force-static'
@@ -35,6 +37,22 @@ export const metadata: Metadata = {
   },
 }
 
-export default function RevenueOperationsCenterPage() {
-  return <RevenueOpsCenterPageContent />
+export default async function RevenueOperationsCenterPage() {
+  const nonce = (await headers()).get('x-nonce')
+  return (
+    <>
+      <BreadcrumbListJsonLd
+        nonce={nonce}
+        items={[
+          { name: 'Home', url: 'https://richardwhudsonjr.com' },
+          { name: 'Projects', url: 'https://richardwhudsonjr.com/projects' },
+          {
+            name: 'Revenue Operations Command Center',
+            url: 'https://richardwhudsonjr.com/projects/revenue-operations-center',
+          },
+        ]}
+      />
+      <RevenueOpsCenterPageContent />
+    </>
+  )
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -146,5 +146,26 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     blogPages = []
   }
 
-  return [...mainPages, ...projectPages, ...blogPages]
+  // Blog category pages — only those with published posts.
+  let categoryPages: MetadataRoute.Sitemap
+  try {
+    const { db } = await import('@/lib/db')
+    const categories = await db.category.findMany({
+      where: { posts: { some: { status: 'PUBLISHED', deletedAt: null } } },
+      select: { slug: true, updatedAt: true },
+    })
+    categoryPages = categories.map((cat) => ({
+      url: `${baseUrl}/blog/category/${cat.slug}`,
+      lastModified: cat.updatedAt?.toISOString() || fallbackDate,
+      changeFrequency: 'weekly' as const,
+      priority: 0.6,
+    }))
+  } catch (error) {
+    logger.warn('Sitemap category query failed; skipping category entries', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    categoryPages = []
+  }
+
+  return [...mainPages, ...projectPages, ...blogPages, ...categoryPages]
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -60,27 +60,41 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ]
 
-  // All project pages (complete list)
+  // All project pages (complete list).
+  // Each entry includes the OG image URL via the `images` field — Next.js
+  // emits this as <image:image><image:loc> per Google's image-sitemap spec.
+  // Only the URL is allowed in MetadataRoute.Sitemap['images']; deprecated
+  // sub-tags (caption/title/license/geo_location) were dropped by Google
+  // in May 2022.
   const projectPages: MetadataRoute.Sitemap = [
-    'revenue-kpi',
-    'revenue-operations-center',
-    'commission-optimization',
-    'multi-channel-attribution',
-    'partnership-program-implementation',
-    'customer-lifetime-value',
-    'partner-performance',
-    'deal-funnel',
-    'churn-retention',
-    'lead-attribution',
-    'cac-unit-economics',
-    'forecast-pipeline-intelligence',
-    'quota-territory-management',
-    'sales-enablement',
-  ].map((project) => ({
-    url: `${baseUrl}/projects/${project}`,
+    { slug: 'revenue-kpi', title: 'Revenue Operations Dashboard' },
+    { slug: 'revenue-operations-center', title: 'Revenue Operations Command Center' },
+    { slug: 'commission-optimization', title: 'Commission & Incentive Optimization' },
+    { slug: 'multi-channel-attribution', title: 'Multi-Channel Attribution Analytics' },
+    {
+      slug: 'partnership-program-implementation',
+      title: 'Partnership Program Implementation',
+    },
+    { slug: 'customer-lifetime-value', title: 'Customer Lifetime Value Analytics' },
+    { slug: 'partner-performance', title: 'Partner Performance Intelligence' },
+    { slug: 'deal-funnel', title: 'Sales Funnel Optimization' },
+    { slug: 'churn-retention', title: 'Customer Churn Prediction Model' },
+    { slug: 'lead-attribution', title: 'Marketing Attribution Platform' },
+    { slug: 'cac-unit-economics', title: 'Customer Acquisition Cost Optimization' },
+    { slug: 'forecast-pipeline-intelligence', title: 'Forecast & Pipeline Intelligence' },
+    { slug: 'quota-territory-management', title: 'Quota & Territory Management' },
+    { slug: 'sales-enablement', title: 'Sales Enablement Platform' },
+  ].map(({ slug, title }) => ({
+    url: `${baseUrl}/projects/${slug}`,
     lastModified: staticLastModified,
     changeFrequency: 'monthly' as const,
     priority: 0.8,
+    images: [
+      `${baseUrl}/api/og?${new URLSearchParams({
+        title,
+        subtitle: 'Revenue Operations Project',
+      }).toString()}`,
+    ],
   }))
 
   // During build, skip DB — blog posts are added on first ISR revalidation
@@ -96,19 +110,33 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       where: { status: 'PUBLISHED' },
       select: {
         slug: true,
+        title: true,
         updatedAt: true,
         publishedAt: true,
+        featuredImage: true,
       },
       orderBy: { publishedAt: 'desc' },
     })
 
-    blogPages = posts.map((post) => ({
-      url: `${baseUrl}/blog/${post.slug}`,
-      lastModified:
-        post.updatedAt?.toISOString() || post.publishedAt?.toISOString() || fallbackDate,
-      changeFrequency: 'monthly' as const,
-      priority: 0.7,
-    }))
+    blogPages = posts.map((post) => {
+      const featuredAbsolute = post.featuredImage
+        ? post.featuredImage.startsWith('http')
+          ? post.featuredImage
+          : `${baseUrl}${post.featuredImage}`
+        : `${baseUrl}/api/og?${new URLSearchParams({
+            title: post.title,
+            subtitle: 'Blog Post',
+          }).toString()}`
+
+      return {
+        url: `${baseUrl}/blog/${post.slug}`,
+        lastModified:
+          post.updatedAt?.toISOString() || post.publishedAt?.toISOString() || fallbackDate,
+        changeFrequency: 'monthly' as const,
+        priority: 0.7,
+        images: [featuredAbsolute],
+      }
+    })
   } catch (error) {
     // Sitemap degrades gracefully to static pages — surface as warn so we
     // notice the regression without paging anyone.

--- a/src/components/blog/__tests__/related-posts.test.ts
+++ b/src/components/blog/__tests__/related-posts.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { selectRelatedPosts, type RelatedPostInput } from '../related-posts-utils'
+
+describe('selectRelatedPosts', () => {
+  const allPosts: RelatedPostInput[] = [
+    { slug: 'a', title: 'A', tags: ['revops', 'salesforce'], publishedAt: '2026-01-01' },
+    { slug: 'b', title: 'B', tags: ['revops', 'hubspot'], publishedAt: '2026-02-01' },
+    { slug: 'c', title: 'C', tags: ['marketing'], publishedAt: '2026-03-01' },
+    { slug: 'd', title: 'D', tags: ['salesforce', 'commission'], publishedAt: '2026-04-01' },
+  ]
+
+  it('excludes the current post', () => {
+    const current = allPosts[0]
+    if (!current) throw new Error('test fixture missing')
+    const result = selectRelatedPosts(allPosts, current, 3)
+    expect(result.find((p) => p.slug === 'a')).toBeUndefined()
+  })
+
+  it('prioritizes posts that share at least one tag', () => {
+    const current = allPosts[0]
+    if (!current) throw new Error('test fixture missing')
+    const result = selectRelatedPosts(allPosts, current, 2)
+    // a has revops+salesforce — b shares revops, d shares salesforce
+    expect(result.map((p) => p.slug).sort()).toEqual(['b', 'd'])
+  })
+
+  it('falls back to most-recent posts if no tag overlap', () => {
+    const isolated: RelatedPostInput = {
+      slug: 'x',
+      title: 'X',
+      tags: ['novel'],
+      publishedAt: '2026-05-01',
+    }
+    const result = selectRelatedPosts(allPosts, isolated, 2)
+    // Most recent first: d (Apr), c (Mar)
+    expect(result.map((p) => p.slug)).toEqual(['d', 'c'])
+  })
+
+  it('respects the limit', () => {
+    const current = allPosts[0]
+    if (!current) throw new Error('test fixture missing')
+    const result = selectRelatedPosts(allPosts, current, 1)
+    expect(result.length).toBe(1)
+  })
+})

--- a/src/components/blog/related-posts-utils.ts
+++ b/src/components/blog/related-posts-utils.ts
@@ -1,0 +1,43 @@
+export interface RelatedPostInput {
+  slug: string
+  title: string
+  tags: string[]
+  publishedAt: string
+}
+
+/**
+ * Select up to `limit` related posts:
+ *   1. Posts sharing at least one tag with `current`, sorted by tag-overlap count desc
+ *   2. Tiebreak by most-recent publishedAt
+ *   3. Fall back to most-recent posts (without tag overlap) to fill remaining slots
+ * Always excludes `current` itself.
+ */
+export function selectRelatedPosts<T extends RelatedPostInput>(
+  all: T[],
+  current: T,
+  limit: number
+): T[] {
+  const others = all.filter((p) => p.slug !== current.slug)
+  const tagged = others
+    .map((p) => ({
+      post: p,
+      overlap: p.tags.filter((t) => current.tags.includes(t)).length,
+    }))
+    .filter((x) => x.overlap > 0)
+    .sort((a, b) => {
+      if (b.overlap !== a.overlap) return b.overlap - a.overlap
+      return new Date(b.post.publishedAt).getTime() - new Date(a.post.publishedAt).getTime()
+    })
+    .slice(0, limit)
+    .map((x) => x.post)
+
+  if (tagged.length >= limit) return tagged
+
+  const taggedSlugs = new Set(tagged.map((p) => p.slug))
+  const fallback = others
+    .filter((p) => !taggedSlugs.has(p.slug))
+    .sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime())
+    .slice(0, limit - tagged.length)
+
+  return [...tagged, ...fallback]
+}

--- a/src/components/blog/related-posts.tsx
+++ b/src/components/blog/related-posts.tsx
@@ -1,0 +1,69 @@
+import Link from 'next/link'
+import { db } from '@/lib/db'
+import { selectRelatedPosts, type RelatedPostInput } from './related-posts-utils'
+
+interface RelatedPostsProps {
+  currentSlug: string
+  currentTags: string[]
+  limit?: number
+}
+
+export async function RelatedPosts({ currentSlug, currentTags, limit = 3 }: RelatedPostsProps) {
+  const safeLimit = Math.min(limit, 3)
+
+  const posts = await db.blogPost.findMany({
+    where: { status: 'PUBLISHED', deletedAt: null, NOT: { slug: currentSlug } },
+    select: {
+      slug: true,
+      title: true,
+      excerpt: true,
+      publishedAt: true,
+      tags: { select: { tag: { select: { name: true } } } },
+    },
+    orderBy: { publishedAt: 'desc' },
+    take: 50,
+  })
+
+  const candidates: (RelatedPostInput & { excerpt: string | null })[] = posts.map((p) => ({
+    slug: p.slug,
+    title: p.title,
+    tags: p.tags.map((t) => t.tag.name),
+    publishedAt: p.publishedAt?.toISOString() ?? '1970-01-01',
+    excerpt: p.excerpt,
+  }))
+
+  const current: RelatedPostInput & { excerpt: string | null } = {
+    slug: currentSlug,
+    title: '',
+    tags: currentTags,
+    publishedAt: '',
+    excerpt: null,
+  }
+  const related = selectRelatedPosts(candidates, current, safeLimit)
+
+  if (related.length === 0) return null
+
+  return (
+    <aside className="mt-16 pt-12 border-t border-border" aria-labelledby="related-posts-heading">
+      <h2 id="related-posts-heading" className="text-2xl font-semibold mb-6 text-foreground">
+        Related reading
+      </h2>
+      <div className="grid md:grid-cols-3 gap-6">
+        {related.map((post) => (
+          <Link
+            key={post.slug}
+            href={`/blog/${post.slug}`}
+            className="group rounded-xl border border-border bg-card p-5 hover:border-primary transition-colors"
+          >
+            <h3 className="font-semibold mb-2 text-foreground group-hover:text-primary transition-colors">
+              {post.title}
+            </h3>
+            {post.excerpt && (
+              <p className="text-sm text-muted-foreground line-clamp-2">{post.excerpt}</p>
+            )}
+          </Link>
+        ))}
+      </div>
+    </aside>
+  )
+}

--- a/src/components/layout/home-page-content.tsx
+++ b/src/components/layout/home-page-content.tsx
@@ -394,6 +394,78 @@ export default function HomePageContent() {
         </div>
       </section>
 
+      {/* Featured Work — direct links to flagship projects.
+          Per Mueller SEO Office Hours: home pages forward PageRank;
+          content closer to home is crawled faster. Selecting 4 flagship
+          projects (not all 8) preserves clear hierarchy. */}
+      <section className="relative py-16 lg:py-24">
+        <div className="relative max-w-7xl mx-auto px-6 lg:px-8">
+          <div className="mb-12">
+            <h2 className="font-display text-3xl md:text-4xl lg:text-5xl font-bold text-foreground mb-4">
+              Featured Work
+            </h2>
+            <p className="text-lg text-muted-foreground max-w-2xl">
+              Selected revenue operations projects with measured business impact.
+            </p>
+          </div>
+          <div className="grid md:grid-cols-2 gap-6 mb-8">
+            <Link
+              href="/projects/revenue-kpi"
+              className="group rounded-2xl border border-border bg-card p-6 hover:border-primary transition-colors"
+            >
+              <h3 className="text-xl font-semibold mb-2 text-foreground group-hover:text-primary transition-colors">
+                Revenue Operations Dashboard
+              </h3>
+              <p className="text-muted-foreground">
+                Real-time revenue tracking and forecasting platform with advanced analytics.
+              </p>
+            </Link>
+            <Link
+              href="/projects/forecast-pipeline-intelligence"
+              className="group rounded-2xl border border-border bg-card p-6 hover:border-primary transition-colors"
+            >
+              <h3 className="text-xl font-semibold mb-2 text-foreground group-hover:text-primary transition-colors">
+                Forecast & Pipeline Intelligence
+              </h3>
+              <p className="text-muted-foreground">
+                Predictive forecasting improving accuracy by 31% and reducing slippage 26%.
+              </p>
+            </Link>
+            <Link
+              href="/projects/partnership-program-implementation"
+              className="group rounded-2xl border border-border bg-card p-6 hover:border-primary transition-colors"
+            >
+              <h3 className="text-xl font-semibold mb-2 text-foreground group-hover:text-primary transition-colors">
+                Partnership Program Implementation
+              </h3>
+              <p className="text-muted-foreground">
+                Built first partnership program from scratch with 90%+ automation.
+              </p>
+            </Link>
+            <Link
+              href="/projects/sales-enablement"
+              className="group rounded-2xl border border-border bg-card p-6 hover:border-primary transition-colors"
+            >
+              <h3 className="text-xl font-semibold mb-2 text-foreground group-hover:text-primary transition-colors">
+                Sales Enablement Platform
+              </h3>
+              <p className="text-muted-foreground">
+                Training and coaching platform increasing win rates by 34%.
+              </p>
+            </Link>
+          </div>
+          <div className="text-center">
+            <Link
+              href="/projects"
+              className="inline-flex items-center gap-2 text-primary hover:underline font-medium"
+            >
+              View all projects
+              <ArrowRight className="w-4 h-4" />
+            </Link>
+          </div>
+        </div>
+      </section>
+
       {/* Final CTA Section - Clean & Consistent */}
       <section className="relative py-16 lg:py-20 overflow-hidden">
         {/* Subtle decorative elements */}

--- a/src/components/seo/json-ld/person-json-ld.tsx
+++ b/src/components/seo/json-ld/person-json-ld.tsx
@@ -100,6 +100,13 @@ export function PersonJsonLd({ nonce }: { nonce?: string | null }) {
       '432% Transaction Growth Achieved',
       '2,217% Network Expansion',
     ],
+    alumniOf: [
+      {
+        '@type': 'CollegeOrUniversity',
+        name: 'The University of Texas at Dallas',
+        url: 'https://www.utdallas.edu',
+      },
+    ],
     memberOf: [
       {
         '@type': 'ProfessionalService',

--- a/src/lib/__tests__/json-ld-schemas.test.ts
+++ b/src/lib/__tests__/json-ld-schemas.test.ts
@@ -103,6 +103,13 @@ function buildPersonJsonLd() {
       '432% Transaction Growth Achieved',
       '2,217% Network Expansion',
     ],
+    alumniOf: [
+      {
+        '@type': 'CollegeOrUniversity',
+        name: 'The University of Texas at Dallas',
+        url: 'https://www.utdallas.edu',
+      },
+    ],
     memberOf: [
       {
         '@type': 'ProfessionalService',
@@ -153,6 +160,16 @@ describe('PersonJsonLd schema', () => {
     const result = safeJsonLdStringify(malicious)
     expect(result).not.toContain('</script>')
     expect(result).toContain('<\\/script>')
+  })
+
+  it('contains alumniOf with University of Texas at Dallas', () => {
+    expect(personData).toHaveProperty('alumniOf')
+    expect(Array.isArray(personData.alumniOf)).toBe(true)
+    expect(personData.alumniOf[0]).toMatchObject({
+      '@type': 'CollegeOrUniversity',
+      name: 'The University of Texas at Dallas',
+      url: 'https://www.utdallas.edu',
+    })
   })
 })
 


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m 
[38;5;8m   3[0m [37mCloses 9 evidence-backed SEO/AI-search gaps from the 2026-05 audit. Each commit cites a primary 2024–2026 source (Google Search Central, Schema.org, IndieWeb spec, Mueller SEO Office Hours, Next.js Metadata API). Two findings explicitly dropped with citations.[0m
[38;5;8m   4[0m 
[38;5;8m   5[0m [37m## Findings shipped (8 commits)[0m
[38;5;8m   6[0m 
[38;5;8m   7[0m [37m| Commit | Finding | Source |[0m
[38;5;8m   8[0m [37m|---|---|---|[0m
[38;5;8m   9[0m [37m| `d8798c4` | `<link rel="me">` × 3 (LinkedIn, GitHub, Twitter) for IndieWeb identity | indieweb.org/rel-me |[0m
[38;5;8m  10[0m [37m| `fb3594e` | Image sitemap (`<image:image>`) for projects + blog | developers.google.com/search/docs/crawling-indexing/sitemaps/image-sitemaps |[0m
[38;5;8m  11[0m [37m| `8a21bd4` | `ProjectJsonLd` on 6 verified-ready project pages (re-evaluated c612cfd's defer) | developers.google.com/search/docs/appearance/structured-data/article |[0m
[38;5;8m  12[0m [37m| `cbc45b3` | Visible service-area copy on `/contact` matching `areaServed` JSON-LD | developers.google.com/search/docs/appearance/structured-data/sd-policies |[0m
[38;5;8m  13[0m [37m| `6b6818d` | `Person.alumniOf` (UTD) | schema.org/alumniOf |[0m
[38;5;8m  14[0m [37m| `d989002` | Homepage Featured Work section → 4 flagship projects (selective hub-and-spoke) | Mueller SEO Office Hours |[0m
[38;5;8m  15[0m [37m| `814f83b` | `RelatedPosts` widget on blog posts (TDD, 4 unit tests) | Mueller SEO Office Hours |[0m
[38;5;8m  16[0m [37m| `e8060ee` | New `/blog/category/[slug]` route consuming `BlogCategoryJsonLd` (was dead code) | Schema.org `CollectionPage` + `BreadcrumbList` |[0m
[38;5;8m  17[0m 
[38;5;8m  18[0m [37m**No-op (verified):** `creator` metadata — already at root `shared-metadata.ts`; Next.js shallow-merge propagates to all child pages.[0m
[38;5;8m  19[0m 
[38;5;8m  20[0m [37m## Findings dropped (cited)[0m
[38;5;8m  21[0m 
[38;5;8m  22[0m [37m- **Speakable schema** — *"This feature is in beta and subject to change"* (Google docs). 8-yr beta, US-only, Google Home only, no expansion since 2018, news-article specific. Zero ROI for a portfolio.[0m
[38;5;8m  23[0m [37m- **JSON Feed alternate link** — jsonfeed.org spec frozen since Aug 2020. No documented evidence GPTBot/ClaudeBot/PerplexityBot/OAI-SearchBot consume it (Cloudflare 2025 + Vercel 2026 crawler reports). RSS is already implemented.[0m
[38;5;8m  24[0m 
[38;5;8m  25[0m [37m## Verification[0m
[38;5;8m  26[0m 
[38;5;8m  27[0m [37m- [x] `bun run lint` — clean (1 pre-existing exhaustive-deps warning, unchanged)[0m
[38;5;8m  28[0m [37m- [x] `bun run typecheck` — clean[0m
[38;5;8m  29[0m [37m- [x] `bunx vitest run` — 181/181 pass (was 176; +4 selectRelatedPosts tests, +1 alumniOf assertion)[0m
[38;5;8m  30[0m [37m- [x] `bun run build` — production build succeeds; new `/blog/category/[slug]` route emitted as dynamic-server (`ƒ`)[0m
[38;5;8m  31[0m 
[38;5;8m  32[0m [37m## Test plan[0m
[38;5;8m  33[0m 
[38;5;8m  34[0m [37m- [ ] CI passes[0m
[38;5;8m  35[0m [37m- [ ] Vercel preview renders OK at `/`, `/contact`, `/blog/[any-slug]`, `/projects/cac-unit-economics`, `/blog/category/[any-slug]`[0m
[38;5;8m  36[0m [37m- [ ] Google Rich Results Test on preview URLs surfaces: `Article` (project pages), `BlogPosting` (blog posts), `ProfessionalService` (contact), `CollectionPage` + `BreadcrumbList` (category pages), `Person` with new `alumniOf` field (homepage)[0m
[38;5;8m  37[0m [37m- [ ] Sitemap at `/sitemap.xml` includes `xmlns:image` namespace + `<image:image><image:loc>` blocks under project + blog entries[0m
[38;5;8m  38[0m 
[38;5;8m  39[0m [37m[hudsor01][0m