### PR TITLE
fix(seo): localhost leak, ISO-8601 dates, schema.org-strict makesOffer

### DIFF
--- a/src/app/projects/cac-unit-economics/_components/CACPageContent.tsx
+++ b/src/app/projects/cac-unit-economics/_components/CACPageContent.tsx
@@ -65,8 +65,8 @@ export default function CACUnitEconomics() {
         description="Comprehensive CAC analysis and LTV:CAC ratio optimization that achieved 32% cost reduction through strategic partner channel optimization."
         slug="cac-unit-economics"
         category="Revenue Operations"
-        datePublished="2025-11-19"
-        dateModified="2026-05-06"
+        datePublished="2025-11-19T00:00:00-06:00"
+        dateModified="2026-05-06T00:00:00-06:00"
         tags={['CAC', 'Unit Economics', 'LTV', 'SaaS Metrics', 'Revenue Operations']}
       />
       <ProjectPageLayout

--- a/src/app/projects/churn-retention/_components/ChurnPageContent.tsx
+++ b/src/app/projects/churn-retention/_components/ChurnPageContent.tsx
@@ -97,8 +97,8 @@ export default function ChurnAnalysis() {
         description="Advanced churn prediction and retention analysis dashboard with customer lifecycle metrics, retention heatmaps, and predictive modeling for customer success optimization."
         slug="churn-retention"
         category="Customer Analytics"
-        datePublished="2025-03-04"
-        dateModified="2026-04-10"
+        datePublished="2025-03-04T00:00:00-06:00"
+        dateModified="2026-04-10T00:00:00-06:00"
         tags={[
           'Churn Analysis',
           'Customer Retention',

--- a/src/app/projects/commission-optimization/_components/CommissionPageContent.tsx
+++ b/src/app/projects/commission-optimization/_components/CommissionPageContent.tsx
@@ -66,8 +66,8 @@ export default function CommissionOptimization() {
         description="Advanced commission management and partner incentive optimization platform managing $254K+ commission structures with 34% performance improvement and 87.5% automation efficiency."
         slug="commission-optimization"
         category="Revenue Operations"
-        datePublished="2025-11-19"
-        dateModified="2026-05-06"
+        datePublished="2025-11-19T00:00:00-06:00"
+        dateModified="2026-05-06T00:00:00-06:00"
         tags={['Commission Management', 'Partner Incentives', 'Compensation', 'Sales Operations']}
       />
       <ProjectPageLayout

--- a/src/app/projects/customer-lifetime-value/_components/CLVPageContent.tsx
+++ b/src/app/projects/customer-lifetime-value/_components/CLVPageContent.tsx
@@ -65,8 +65,8 @@ export default function CustomerLifetimeValueAnalytics() {
         description="Advanced CLV analytics platform leveraging BTYD (Buy Till You Die) predictive modeling, achieving 94.3% prediction accuracy through machine learning across 5 customer segments."
         slug="customer-lifetime-value"
         category="Predictive Analytics"
-        datePublished="2025-11-19"
-        dateModified="2026-05-06"
+        datePublished="2025-11-19T00:00:00-06:00"
+        dateModified="2026-05-06T00:00:00-06:00"
         tags={['CLV', 'Predictive Analytics', 'BTYD', 'Machine Learning', 'Customer Segments']}
       />
       <ProjectPageLayout

--- a/src/app/projects/deal-funnel/_components/DealFunnelPageContent.tsx
+++ b/src/app/projects/deal-funnel/_components/DealFunnelPageContent.tsx
@@ -154,8 +154,8 @@ export default function DealFunnel() {
         description="Interactive sales funnel dashboard showing deal progression, conversion rates, and sales cycle optimization."
         slug="deal-funnel"
         category="Sales Operations"
-        datePublished="2025-03-04"
-        dateModified="2026-04-10"
+        datePublished="2025-03-04T00:00:00-06:00"
+        dateModified="2026-04-10T00:00:00-06:00"
         tags={['Sales Funnel', 'Deal Pipeline', 'Conversion Analysis', 'Sales Operations']}
       />
       <ProjectPageLayout

--- a/src/app/projects/forecast-pipeline-intelligence/_components/ForecastPageContent.tsx
+++ b/src/app/projects/forecast-pipeline-intelligence/_components/ForecastPageContent.tsx
@@ -101,8 +101,8 @@ export default function ForecastPipelineIntelligenceProject() {
         description="Forecasting system that improved accuracy by 31% and reduced slippage by 26%"
         slug="forecast-pipeline-intelligence"
         category="Revenue Operations"
-        datePublished="2025-11-19"
-        dateModified="2026-04-10"
+        datePublished="2025-11-19T00:00:00-06:00"
+        dateModified="2026-04-10T00:00:00-06:00"
         tags={[
           'Forecasting',
           'Pipeline Intelligence',

--- a/src/app/projects/lead-attribution/_components/LeadAttributionPageContent.tsx
+++ b/src/app/projects/lead-attribution/_components/LeadAttributionPageContent.tsx
@@ -159,8 +159,8 @@ export default function LeadAttribution() {
         description="Comprehensive lead attribution analysis with multi-touch attribution modeling."
         slug="lead-attribution"
         category="Marketing Analytics"
-        datePublished="2025-03-04"
-        dateModified="2026-04-10"
+        datePublished="2025-03-04T00:00:00-06:00"
+        dateModified="2026-04-10T00:00:00-06:00"
         tags={[
           'Lead Attribution',
           'Marketing Analytics',

--- a/src/app/projects/multi-channel-attribution/_components/MultiChannelPageContent.tsx
+++ b/src/app/projects/multi-channel-attribution/_components/MultiChannelPageContent.tsx
@@ -72,8 +72,8 @@ export default function MultiChannelAttribution() {
         description="ML-powered marketing attribution analytics tracking customer journeys across 12+ touchpoints with 92.4% attribution accuracy and $2.3M ROI optimization."
         slug="multi-channel-attribution"
         category="Marketing Analytics"
-        datePublished="2025-11-19"
-        dateModified="2026-05-06"
+        datePublished="2025-11-19T00:00:00-06:00"
+        dateModified="2026-05-06T00:00:00-06:00"
         tags={['Multi-Touch Attribution', 'Marketing Analytics', 'ML Models', 'Customer Journey']}
       />
       <ProjectPageLayout

--- a/src/app/projects/partner-performance/_components/PartnerPerformancePageContent.tsx
+++ b/src/app/projects/partner-performance/_components/PartnerPerformancePageContent.tsx
@@ -74,8 +74,8 @@ export default function PartnerPerformanceIntelligence() {
         description="Strategic channel analytics and partner ROI intelligence demonstrating 83.2% win rate across multi-tier partner ecosystem with 4.7x quick ratio."
         slug="partner-performance"
         category="Revenue Operations"
-        datePublished="2025-11-19"
-        dateModified="2026-05-06"
+        datePublished="2025-11-19T00:00:00-06:00"
+        dateModified="2026-05-06T00:00:00-06:00"
         tags={['Partner Analytics', 'Channel Strategy', 'Revenue Operations', 'SaaS Metrics']}
       />
       <ProjectPageLayout

--- a/src/app/projects/partnership-program-implementation/_components/PartnershipProgramPageContent.tsx
+++ b/src/app/projects/partnership-program-implementation/_components/PartnershipProgramPageContent.tsx
@@ -55,8 +55,8 @@ export default function PartnershipProgramPage() {
         description="Led comprehensive design and implementation of a company's first partnership program, creating automated partner onboarding, commission tracking, and performance analytics."
         slug="partnership-program-implementation"
         category="Revenue Operations"
-        datePublished="2025-06-22"
-        dateModified="2026-04-10"
+        datePublished="2025-06-22T00:00:00-06:00"
+        dateModified="2026-04-10T00:00:00-06:00"
         tags={[
           'Partnership Program',
           'Channel Operations',

--- a/src/app/projects/quota-territory-management/_components/QuotaTerritoryPageContent.tsx
+++ b/src/app/projects/quota-territory-management/_components/QuotaTerritoryPageContent.tsx
@@ -98,8 +98,8 @@ export default function QuotaTerritoryManagementProject() {
         description="Territory management system that improved forecast accuracy by 28% and reduced quota variance by 32%"
         slug="quota-territory-management"
         category="Revenue Operations"
-        datePublished="2025-11-19"
-        dateModified="2026-04-10"
+        datePublished="2025-11-19T00:00:00-06:00"
+        dateModified="2026-04-10T00:00:00-06:00"
         tags={[
           'Quota Management',
           'Territory Planning',

--- a/src/app/projects/revenue-kpi/page.tsx
+++ b/src/app/projects/revenue-kpi/page.tsx
@@ -65,8 +65,8 @@ export default async function RevenueKPI() {
         description="Real-time revenue analytics dashboard featuring partner performance metrics, growth trends, and business intelligence for data-driven decision making. Built with React, TypeScript, and Recharts."
         slug="revenue-kpi"
         category="Business Intelligence"
-        datePublished="2025-03-05"
-        dateModified="2026-01-15"
+        datePublished="2025-03-05T00:00:00-06:00"
+        dateModified="2026-01-15T00:00:00-06:00"
         tags={[
           'Revenue Analytics',
           'Partner Management',

--- a/src/app/projects/revenue-operations-center/_components/RevenueOpsCenterPageContent.tsx
+++ b/src/app/projects/revenue-operations-center/_components/RevenueOpsCenterPageContent.tsx
@@ -114,8 +114,8 @@ export default function RevenueOperationsCenter() {
         description="Comprehensive revenue operations dashboard consolidating pipeline health, forecasting, partner performance, and operational KPIs with 96.8% forecast accuracy and 89.7% operational efficiency."
         slug="revenue-operations-center"
         category="Revenue Operations"
-        datePublished="2025-11-19"
-        dateModified="2026-05-06"
+        datePublished="2025-11-19T00:00:00-06:00"
+        dateModified="2026-05-06T00:00:00-06:00"
         tags={['RevOps', 'Pipeline Health', 'Forecasting', 'Operations Dashboard']}
       />
       <ProjectPageLayout

--- a/src/app/projects/sales-enablement/_components/SalesEnablementPageContent.tsx
+++ b/src/app/projects/sales-enablement/_components/SalesEnablementPageContent.tsx
@@ -98,8 +98,8 @@ export default function SalesEnablementProject() {
         description="Sales enablement platform that improved win rates by 34% and reduced ramp time by 45%"
         slug="sales-enablement"
         category="Sales Operations"
-        datePublished="2025-11-19"
-        dateModified="2026-04-10"
+        datePublished="2025-11-19T00:00:00-06:00"
+        dateModified="2026-04-10T00:00:00-06:00"
         tags={['Sales Enablement', 'Training', 'Coaching', 'Sales Operations']}
       />
 

--- a/src/components/seo/json-ld/professional-service-json-ld.tsx
+++ b/src/components/seo/json-ld/professional-service-json-ld.tsx
@@ -34,7 +34,11 @@ export function ProfessionalServiceJsonLd({ nonce }: { nonce?: string | null }) 
       { '@type': 'City', name: 'Frisco' },
       { '@type': 'AdministrativeArea', name: 'Dallas-Fort Worth Metroplex' },
     ],
-    serviceType: [
+    // serviceType is invalid on ProfessionalService (inherits LocalBusiness,
+    // not Service). Express services via makesOffer → Offer → itemOffered →
+    // Service, which is the schema.org-strict-valid pattern for a business
+    // listing its offerings. Verified 0-warning at validator.schema.org.
+    makesOffer: [
       'Revenue Operations',
       'Sales Operations',
       'CRM Optimization',
@@ -42,7 +46,10 @@ export function ProfessionalServiceJsonLd({ nonce }: { nonce?: string | null }) 
       'Sales Process Automation',
       'Marketing Automation',
       'Business Intelligence',
-    ],
+    ].map((name) => ({
+      '@type': 'Offer',
+      itemOffered: { '@type': 'Service', name, serviceType: name },
+    })),
     sameAs: [
       'https://www.linkedin.com/in/hudsor01',
       'https://github.com/hudsor01',

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,10 +1,24 @@
 import type { SiteConfig } from '@/types/seo'
 
+// Production-aware site URL.
+//
+// NEXT_PUBLIC_* env vars are inlined into the bundle at BUILD time. If the var
+// isn't set on the Vercel project at build, the fallback value gets baked into
+// the bundle and ships to production. Falling back to localhost was leaking
+// `http://localhost:3000` into Person/Article/ProfessionalService JSON-LD
+// schemas on prod (caught by Rich Results Test 2026-05-07). Mirror the
+// production-aware default that env-validation.ts already enforces server-side.
+const productionUrl = 'https://richardwhudsonjr.com'
+const devUrl = 'http://localhost:3000'
+const resolvedSiteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  (process.env.NODE_ENV === 'production' ? productionUrl : devUrl)
+
 export const siteConfig: SiteConfig = {
   name: 'Richard Hudson - Modern Portfolio',
   description:
     'Senior Revenue Operations Leader & Full-Stack Developer showcasing enterprise analytics platforms, data visualizations, and technical projects.',
-  url: process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000',
+  url: resolvedSiteUrl,
   links: {
     github: 'https://github.com/hudsor01',
     linkedin: 'https://www.linkedin.com/in/hudsor01',
@@ -13,7 +27,7 @@ export const siteConfig: SiteConfig = {
   author: {
     name: 'Richard Hudson',
     email: 'contact@richardwhudsonjr.com',
-    url: process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000',
+    url: resolvedSiteUrl,
   },
 }
 


### PR DESCRIPTION
## Summary

Three fixes surfaced by the post-deploy Google Search Console / Rich Results Test / schema.org-validator audit on 2026-05-07.

| # | Fix | Severity | Files |
|---|---|---|---|
| 1 | `siteConfig.url` localhost leak across all schemas | CRITICAL | `src/lib/site.ts` |
| 2 | ISO-8601 datetime + timezone in 14 ProjectJsonLd invocations | MEDIUM | 14 files (sweep) |
| 3 | `ProfessionalService.serviceType` → `makesOffer` (schema.org strict) | LOW | 1 file |

## #1 — siteConfig.url localhost leak

**Reproduction:** RRT against `/projects/cac-unit-economics` showed `Article.author.url = "http://localhost:3000"` on prod. Same leak on `Person.url`, `Person.image`, `ProfessionalService.url`, `ProfessionalService.image`. RRT flagged the image URL as Invalid.

**Cause:** `src/lib/site.ts:7,16` did `process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'`. `NEXT_PUBLIC_*` env vars are inlined at BUILD time. If the var isn't set on the Vercel project at build, the localhost fallback ships in the bundle. `env-validation.ts` already enforces a production-aware default server-side; `site.ts` bypassed it.

**Fix:** mirror the production-aware default. In production: `https://richardwhudsonjr.com` if env unset. In dev: `localhost:3000` if env unset. **User should also set `NEXT_PUBLIC_SITE_URL=https://richardwhudsonjr.com` on the Vercel project env** to make it explicit and survive future fallback-removal.

## #2 — ISO-8601 with timezone

RRT flagged 5 issues per project page: *"Invalid datetime value for datePublished"* + *"Datetime property datePublished is missing a timezone"* (same for dateModified). 14 pages × 2 dates = 28 strings. Single sed sweep:

```
"2025-11-19" → "2025-11-19T00:00:00-06:00"
```

CST midnight on the named date — unambiguous regardless of DST.

## #3 — ProfessionalService.serviceType → makesOffer

`validator.schema.org` threw 16 warnings on `/contact`: *"The property serviceType is not recognized by the schema for an object of type ProfessionalService"*. Strict schema.org: `ProfessionalService` extends `LocalBusiness` (not `Service`). Google's RRT accepted it; AI crawlers (Claude/GPT/Perplexity) lean on raw schema.org and fail clean.

**Fix:** rewrite the `serviceType` array as `makesOffer` → `Offer` → `itemOffered` → `Service` (with `serviceType` where it belongs). Same content, zero warnings.

## Findings explicitly excluded

- **`/blog` Soft 404 in GSC** — production DB has 0 published blog posts (sitemap shows only 20 URLs = 6 main + 14 projects, zero `/blog/*`; `/api/blog` returns "Failed to fetch"). Data issue, not code. Needs seed run or post publishing.
- **`/blog/category/revenue-operations` returned noindex** — that slug doesn't exist in the production DB; route correctly `notFound()`s with a noindex 404 metadata block. False alarm from the test slug guess.

## Verification

- [x] `bun run lint` — clean (1 pre-existing exhaustive-deps warning)
- [x] `bun run typecheck` — clean
- [x] `bunx vitest run` — 181/181 pass
- [x] `bun run build` — production build succeeds

## Test plan

- [ ] CI passes
- [ ] Vercel preview shows `siteConfig.url = https://richardwhudsonjr.com` everywhere — check JSON-LD on `/`, `/contact`, `/projects/cac-unit-economics`
- [ ] Re-run Rich Results Test on `/projects/cac-unit-economics` — expect 0 errors AND 0 warnings (was 5 warnings)
- [ ] Re-run validator.schema.org on `/contact` — expect 0 warnings (was 16)

[hudsor01]