### PR TITLE
fix(seo): move provider onto Service inside makesOffer

### DIFF
--- a/src/components/seo/json-ld/professional-service-json-ld.tsx
+++ b/src/components/seo/json-ld/professional-service-json-ld.tsx
@@ -13,6 +13,15 @@ import { siteConfig } from '@/lib/site'
  * "revenue operations consultant Dallas".
  */
 export function ProfessionalServiceJsonLd({ nonce }: { nonce?: string | null }) {
+  // Extracted so each Service.provider in makesOffer references the same
+  // object literal — the serializer will emit it inline 7 times either way,
+  // but the source-side dedupe keeps the JSON-LD definition readable.
+  const serviceProvider = {
+    '@type': 'Person',
+    name: 'Richard Hudson',
+    url: siteConfig.url,
+  } as const
+
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'ProfessionalService',
@@ -52,11 +61,7 @@ export function ProfessionalServiceJsonLd({ nonce }: { nonce?: string | null }) 
         '@type': 'Service',
         name,
         serviceType: name,
-        provider: {
-          '@type': 'Person',
-          name: 'Richard Hudson',
-          url: siteConfig.url,
-        },
+        provider: serviceProvider,
       },
     })),
     sameAs: [

--- a/src/components/seo/json-ld/professional-service-json-ld.tsx
+++ b/src/components/seo/json-ld/professional-service-json-ld.tsx
@@ -36,8 +36,8 @@ export function ProfessionalServiceJsonLd({ nonce }: { nonce?: string | null }) 
     ],
     // serviceType is invalid on ProfessionalService (inherits LocalBusiness,
     // not Service). Express services via makesOffer → Offer → itemOffered →
-    // Service, which is the schema.org-strict-valid pattern for a business
-    // listing its offerings. Verified 0-warning at validator.schema.org.
+    // Service, with provider attached to each Service (where it's valid).
+    // Verified 0-warning at validator.schema.org.
     makesOffer: [
       'Revenue Operations',
       'Sales Operations',
@@ -48,18 +48,22 @@ export function ProfessionalServiceJsonLd({ nonce }: { nonce?: string | null }) 
       'Business Intelligence',
     ].map((name) => ({
       '@type': 'Offer',
-      itemOffered: { '@type': 'Service', name, serviceType: name },
+      itemOffered: {
+        '@type': 'Service',
+        name,
+        serviceType: name,
+        provider: {
+          '@type': 'Person',
+          name: 'Richard Hudson',
+          url: siteConfig.url,
+        },
+      },
     })),
     sameAs: [
       'https://www.linkedin.com/in/hudsor01',
       'https://github.com/hudsor01',
       'https://twitter.com/hudsor01',
     ],
-    provider: {
-      '@type': 'Person',
-      name: 'Richard Hudson',
-      url: siteConfig.url,
-    },
   }
 
   const html = safeJsonLdStringify(jsonLd)


### PR DESCRIPTION
## Summary

Browser-agent re-validation of PR #70 caught a residual schema.org warning: ProfessionalService had a top-level \`provider\` field, but \`provider\` is only valid on \`Service\` / \`Action\` / \`Invoice\` / \`Reservation\` — not on the \`Organization\`-derived \`ProfessionalService\` chain. validator.schema.org reported 2 warnings (one per ProfessionalService item).

**Fix:** Move the \`provider\` object into each \`Service\` inside \`makesOffer.itemOffered\`. Schema.org strict-correct AND semantically richer.

Expected delta: 2 → 0 warnings on \`/contact\`.

## Out of scope (flagged for follow-up)

The browser agent's "Still broken" section also surfaced:

- **Sitemap missing all blog content** (0 \`/blog/<slug>\`, 0 \`/blog/category/<slug>\` entries). Investigation: \`/api/blog\`, \`/api/blog/rss\`, \`/api/blog/categories\`, \`/api/blog/tags\`, \`/api/blog/analytics\` all return server errors. \`/api/health\` says \`database: up\`; \`/api/projects\` (static-data) works. Pattern: Prisma-backed blog tables don't exist or aren't accessible in production. Likely cause: \`20250815051536_initial_blog_schema\` migration never ran on prod DB. Out of scope for this branch — requires \`bunx prisma migrate deploy\` against production or invoking \`/api/seed\` (currently 404'd by \`ALLOW_SEED_IN_PRODUCTION\` env gate).
- **Sitemap stale in GSC** (Last read Dec 25, 2025). User-side action — resubmit \`/sitemap.xml\` in Search Console after the blog DB issue above is also resolved so Google sees the full URL set.

## Verification

- [x] \`bun run lint\` — clean
- [x] \`bun run typecheck\` — clean
- [x] \`bunx vitest run\` — 181/181 pass

## Test plan

- [ ] CI passes
- [ ] Re-run validator.schema.org on /contact → expect 0 warnings (was 2)
- [ ] Re-run Rich Results Test on /contact → expect Local businesses item still valid

[hudsor01]