### PR TITLE
fix(seo): force-dynamic sitemap to include blog + category URLs

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,7 +3,17 @@ import { createContextLogger } from '@/lib/logger'
 
 const logger = createContextLogger('Sitemap')
 
-// Revalidate sitemap every hour to include new blog posts from n8n automation
+// Force dynamic rendering at request time. The previous setup (revalidate
+// = 3600 only) caused Next.js to statically prerender the sitemap during
+// `next build` — which always took the NEXT_PHASE === 'phase-production-build'
+// short-circuit branch (no DB query). Result: blog/category URLs never
+// appeared in production sitemap until a non-build trigger forced ISR
+// regen, and Vercel often served the static artifact indefinitely.
+//
+// With force-dynamic, the sitemap renders at runtime on every request,
+// guaranteeing blog/category URLs are always fresh from the DB.
+// `revalidate = 3600` still applies as a CDN cache hint.
+export const dynamic = 'force-dynamic'
 export const revalidate = 3600
 
 // Captured at module load (i.e. deploy time / process start), NOT per


### PR DESCRIPTION
## Summary

Production sitemap was permanently missing all blog + category URLs (only 20 URLs = 6 main + 14 projects, despite 21 PUBLISHED posts in the DB).

## Root cause

\`src/app/sitemap.ts\` had only \`export const revalidate = 3600\` — Next.js marked it as statically prerendered (build output: \`○ /sitemap.xml\`). At build time, the function takes the \`NEXT_PHASE === 'phase-production-build'\` short-circuit branch which returns mainPages + projectPages without a DB query (added intentionally to avoid build-time DB calls). The build artifact is what Vercel's CDN serves.

ISR (\`revalidate = 3600\`) was supposed to regenerate hourly, but for fully-static routes Vercel can serve the build-time artifact indefinitely. Even a clean production redeploy with the (now-fixed) DATABASE_URL re-rendered the sitemap with the same short-circuit, emitting 0 blog URLs again.

## Fix

\`export const dynamic = 'force-dynamic'\` — sitemap renders at runtime on every request. The DB query runs against the live runtime DATABASE_URL. \`revalidate = 3600\` retained as CDN cache hint.

## Verification

- [x] \`bun run typecheck\` clean
- [ ] After deploy, \`curl -s https://richardwhudsonjr.com/sitemap.xml | grep -c '<url>'\` → expect 26+ (was 20)
- [ ] \`grep -c 'blog/[a-z0-9-]'\` → expect 21+ blog URLs
- [ ] \`grep -c 'blog/category/'\` → expect 5+ category URLs

[hudsor01]