### PR TITLE
fix(seo): remove duplicated brand suffix from page titles

### DIFF
--- a/src/app/blog/category/[slug]/page.tsx
+++ b/src/app/blog/category/[slug]/page.tsx
@@ -80,7 +80,7 @@ export async function generateMetadata({ params }: BlogCategoryPageProps): Promi
     }
   }
 
-  const title = `${category.name} — Articles | Richard Hudson`
+  const title = `${category.name} — Articles`
   const description =
     category.description ||
     `Articles about ${category.name} from Richard Hudson's revenue operations blog.`

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -19,7 +19,7 @@ const BLOG_INDEX_OG_IMAGE_URL = `https://richardwhudsonjr.com/api/og?${new URLSe
 }).toString()}`
 
 export const metadata: Metadata = {
-  title: 'Blog | Richard Hudson - Revenue Operations Insights',
+  title: 'Blog - Revenue Operations Insights',
   description: 'Insights on revenue operations, data analytics, and business growth strategies.',
   keywords: ['revenue operations', 'data analytics', 'business intelligence', 'revops'],
   openGraph: {

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -56,7 +56,7 @@ export async function generateMetadata({ params }: ProjectPageProps): Promise<Me
   }).toString()}`
 
   return {
-    title: `${project.title} | Richard Hudson`,
+    title: project.title,
     description: project.description,
     openGraph: {
       title: project.title,

--- a/src/app/projects/cac-unit-economics/page.tsx
+++ b/src/app/projects/cac-unit-economics/page.tsx
@@ -11,7 +11,7 @@ const ogImageUrl = `https://richardwhudsonjr.com/api/og?${new URLSearchParams({
 }).toString()}`
 
 export const metadata: Metadata = {
-  title: 'Customer Acquisition Cost Optimization & Unit Economics Dashboard | Richard Hudson',
+  title: 'Customer Acquisition Cost Optimization & Unit Economics Dashboard',
   description:
     'Comprehensive CAC analysis and LTV:CAC ratio optimization that achieved 32% cost reduction through strategic partner channel optimization. Industry-benchmark 3.6:1 efficiency ratio with 8.4-month payback period across multi-tier SaaS products.',
   openGraph: {

--- a/src/app/projects/churn-retention/page.tsx
+++ b/src/app/projects/churn-retention/page.tsx
@@ -11,7 +11,7 @@ const ogImageUrl = `https://richardwhudsonjr.com/api/og?${new URLSearchParams({
 }).toString()}`
 
 export const metadata: Metadata = {
-  title: 'Customer Churn & Retention Analysis - Predictive Analytics | Richard Hudson',
+  title: 'Customer Churn & Retention Analysis - Predictive Analytics',
   description:
     'Advanced churn prediction and retention analysis dashboard with customer lifecycle metrics, retention heatmaps, and predictive modeling for customer success optimization.',
   openGraph: {

--- a/src/app/projects/commission-optimization/page.tsx
+++ b/src/app/projects/commission-optimization/page.tsx
@@ -11,7 +11,7 @@ const ogImageUrl = `https://richardwhudsonjr.com/api/og?${new URLSearchParams({
 }).toString()}`
 
 export const metadata: Metadata = {
-  title: 'Commission & Incentive Optimization System | Richard Hudson',
+  title: 'Commission & Incentive Optimization System',
   description:
     'Advanced commission management and partner incentive optimization platform managing $254K+ commission structures. Automated tier adjustments with 23% average commission rate optimization and ROI-driven compensation strategy delivering 34% performance improvement and 87.5% automation efficiency.',
   openGraph: {

--- a/src/app/projects/customer-lifetime-value/page.tsx
+++ b/src/app/projects/customer-lifetime-value/page.tsx
@@ -11,7 +11,7 @@ const ogImageUrl = `https://richardwhudsonjr.com/api/og?${new URLSearchParams({
 }).toString()}`
 
 export const metadata: Metadata = {
-  title: 'Customer Lifetime Value Predictive Analytics Dashboard | Richard Hudson',
+  title: 'Customer Lifetime Value Predictive Analytics Dashboard',
   description:
     'Advanced CLV analytics platform leveraging BTYD (Buy Till You Die) predictive modeling framework. Achieving 94.3% prediction accuracy through machine learning algorithms and real-time customer behavior tracking across 5 distinct customer segments.',
   openGraph: {

--- a/src/app/projects/deal-funnel/page.tsx
+++ b/src/app/projects/deal-funnel/page.tsx
@@ -11,7 +11,7 @@ const ogImageUrl = `https://richardwhudsonjr.com/api/og?${new URLSearchParams({
 }).toString()}`
 
 export const metadata: Metadata = {
-  title: 'Sales Pipeline Funnel Analysis - Deal Stage Optimization | Richard Hudson',
+  title: 'Sales Pipeline Funnel Analysis - Deal Stage Optimization',
   description:
     'Interactive sales funnel dashboard showing deal progression, conversion rates, and sales cycle optimization. Tracks pipeline opportunities through each stage with real-time metrics on deal velocity and revenue forecasting.',
   openGraph: {

--- a/src/app/projects/forecast-pipeline-intelligence/page.tsx
+++ b/src/app/projects/forecast-pipeline-intelligence/page.tsx
@@ -11,7 +11,7 @@ const ogImageUrl = `https://richardwhudsonjr.com/api/og?${new URLSearchParams({
 }).toString()}`
 
 export const metadata: Metadata = {
-  title: 'Forecast Accuracy & Pipeline Intelligence System | Richard Hudson',
+  title: 'Forecast Accuracy & Pipeline Intelligence System',
   description:
     'Enterprise forecasting and pipeline intelligence platform combining predictive analytics, deal health monitoring, and early warning systems. Improved forecast accuracy by 31% and reduced slippage by 26%.',
   openGraph: {

--- a/src/app/projects/lead-attribution/page.tsx
+++ b/src/app/projects/lead-attribution/page.tsx
@@ -11,7 +11,7 @@ const ogImageUrl = `https://richardwhudsonjr.com/api/og?${new URLSearchParams({
 }).toString()}`
 
 export const metadata: Metadata = {
-  title: 'Lead Attribution & Marketing Analytics - Multi-Touch Attribution | Richard Hudson',
+  title: 'Lead Attribution & Marketing Analytics - Multi-Touch Attribution',
   description:
     'Comprehensive lead attribution analysis with multi-touch attribution modeling. Tracks lead sources, conversion rates, and marketing channel performance to optimize spend and improve pipeline quality.',
   openGraph: {

--- a/src/app/projects/multi-channel-attribution/page.tsx
+++ b/src/app/projects/multi-channel-attribution/page.tsx
@@ -11,7 +11,7 @@ const ogImageUrl = `https://richardwhudsonjr.com/api/og?${new URLSearchParams({
 }).toString()}`
 
 export const metadata: Metadata = {
-  title: 'Multi-Channel Attribution Analytics Dashboard | Richard Hudson',
+  title: 'Multi-Channel Attribution Analytics Dashboard',
   description:
     'Advanced marketing attribution analytics platform using machine learning models to track customer journeys across 12+ touchpoints. Delivering 92.4% attribution accuracy and $2.3M ROI optimization through data-driven attribution modeling and cross-channel insights.',
   openGraph: {

--- a/src/app/projects/partner-performance/page.tsx
+++ b/src/app/projects/partner-performance/page.tsx
@@ -11,7 +11,7 @@ const ogImageUrl = `https://richardwhudsonjr.com/api/og?${new URLSearchParams({
 }).toString()}`
 
 export const metadata: Metadata = {
-  title: 'Partner Performance Intelligence Dashboard | Richard Hudson',
+  title: 'Partner Performance Intelligence Dashboard',
   description:
     'Strategic channel analytics and partner ROI intelligence demonstrating 83.2% win rate across multi-tier partner ecosystem. Real-time performance tracking following industry-standard 80/20 partner revenue distribution.',
   openGraph: {

--- a/src/app/projects/partnership-program-implementation/page.tsx
+++ b/src/app/projects/partnership-program-implementation/page.tsx
@@ -11,7 +11,7 @@ const ogImageUrl = `https://richardwhudsonjr.com/api/og?${new URLSearchParams({
 }).toString()}`
 
 export const metadata: Metadata = {
-  title: 'Enterprise Partnership Program Implementation | Richard Hudson',
+  title: 'Enterprise Partnership Program Implementation',
   description:
     "Led comprehensive design and implementation of a company's first partnership program, creating automated partner onboarding, commission tracking, and performance analytics. Built production-ready integrations with CRM, billing systems, and partner portals.",
   openGraph: {

--- a/src/app/projects/quota-territory-management/page.tsx
+++ b/src/app/projects/quota-territory-management/page.tsx
@@ -11,7 +11,7 @@ const ogImageUrl = `https://richardwhudsonjr.com/api/og?${new URLSearchParams({
 }).toString()}`
 
 export const metadata: Metadata = {
-  title: 'Intelligent Quota Management & Territory Planning | Richard Hudson',
+  title: 'Intelligent Quota Management & Territory Planning',
   description:
     'Advanced quota setting and territory assignment system using predictive analytics and fairness algorithms. Optimized territory design increased forecast accuracy by 28% and reduced quota attainment variance by 32%.',
   openGraph: {

--- a/src/app/projects/revenue-kpi/page.tsx
+++ b/src/app/projects/revenue-kpi/page.tsx
@@ -15,7 +15,7 @@ const ogImageUrl = `https://richardwhudsonjr.com/api/og?${new URLSearchParams({
 }).toString()}`
 
 export const metadata: Metadata = {
-  title: 'Revenue KPI Dashboard - Partner Analytics & Business Intelligence | Richard Hudson',
+  title: 'Revenue KPI Dashboard - Partner Analytics & Business Intelligence',
   description:
     'Real-time revenue analytics dashboard featuring partner performance metrics, growth trends, and business intelligence for data-driven decision making. Built with React, TypeScript, and Recharts.',
   openGraph: {

--- a/src/app/projects/revenue-operations-center/page.tsx
+++ b/src/app/projects/revenue-operations-center/page.tsx
@@ -11,7 +11,7 @@ const ogImageUrl = `https://richardwhudsonjr.com/api/og?${new URLSearchParams({
 }).toString()}`
 
 export const metadata: Metadata = {
-  title: 'Revenue Operations Command Center | Richard Hudson',
+  title: 'Revenue Operations Command Center',
   description:
     'Comprehensive revenue operations dashboard consolidating pipeline health, forecasting accuracy, partner performance, and operational KPIs. Real-time insights with 96.8% forecast accuracy and 89.7% operational efficiency across sales, marketing, and partner channels.',
   openGraph: {

--- a/src/app/projects/sales-enablement/page.tsx
+++ b/src/app/projects/sales-enablement/page.tsx
@@ -11,7 +11,7 @@ const ogImageUrl = `https://richardwhudsonjr.com/api/og?${new URLSearchParams({
 }).toString()}`
 
 export const metadata: Metadata = {
-  title: 'Sales Enablement & Coaching Platform | Richard Hudson',
+  title: 'Sales Enablement & Coaching Platform',
   description:
     'Transformed sales team performance through structured training, real-time coaching, and continuous skill development. Increased win rates by 34% and reduced ramp time by 45% across a 125-person sales organization.',
   openGraph: {

--- a/src/app/resume/view/page.tsx
+++ b/src/app/resume/view/page.tsx
@@ -8,7 +8,7 @@ import ResumeViewClient from './resume-view-client'
 // just override canonical (→ /resume) and robots (noindex).
 export const metadata: Metadata = {
   ...genMeta(
-    'Resume PDF | Richard Hudson',
+    'Resume PDF',
     'View the resume of Richard Hudson, Revenue Operations Professional.',
     '/resume/view'
   ),


### PR DESCRIPTION
## Summary

Browser-agent re-validation caught duplicated brand suffix in `<title>` tags across 17 routes. Example: `<title>Customer Acquisition Cost Optimization & Unit Economics Dashboard | Richard Hudson | Richard Hudson</title>` (suffix appears twice).

## Cause

\`shared-metadata.ts:7\` sets:
\`\`\`ts
title: { template: '%s | Richard Hudson' }
\`\`\`

Per-page metadata.title fields included the suffix literally, so the template appended a second copy. Per Next.js Metadata API: templates apply ONLY to top-level metadata.title — openGraph.title and twitter.title pass through unchanged, so social-card titles keep their brand suffix legitimately.

## Fix

Stripped \` | Richard Hudson\` from top-level metadata.title in 17 route files:
- 14 static project page.tsx files
- /projects/[slug]/page.tsx (backtick template)
- /blog/page.tsx
- /blog/category/[slug]/page.tsx (backtick template)

Preserved the suffix on openGraph.title and twitter.title (those don't pass through the template, so they need the brand explicitly for social cards).

## Verification

- [x] \`bun run typecheck\` clean
- [x] \`bunx vitest run\` 181/181 pass
- [ ] After deploy: \`<title>\` shows brand suffix exactly once on every route
- [ ] Social cards unchanged (still show 'Blog | Richard Hudson', etc.)

[hudsor01]