### PR TITLE
fix(seo): XML-escape ampersands in sitemap <image:loc> URLs

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -24,6 +24,14 @@ export const revalidate = 3600
 // (Vercel-injected env var), falling back to process start.
 const STATIC_LAST_MODIFIED = process.env.VERCEL_GIT_COMMIT_AUTHOR_DATE || new Date().toISOString()
 
+// Next.js's MetadataRoute.Sitemap serializer does NOT XML-escape `&` in the
+// `images[]` URL strings before emitting them inside <image:loc>. URLs that
+// contain query strings (?title=X&subtitle=Y) ship to Google with literal
+// ampersands, and Google's strict XML parser rejects the whole sitemap
+// ("Parsing error" → Discovered URLs = 0). Pre-escape ourselves; Next.js
+// emits the string as-is into the XML element value.
+const xmlSafeUrl = (url: string): string => url.replace(/&/g, '&amp;')
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = 'https://richardwhudsonjr.com'
   // fallback only for blog posts with null timestamps
@@ -100,10 +108,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     changeFrequency: 'monthly' as const,
     priority: 0.8,
     images: [
-      `${baseUrl}/api/og?${new URLSearchParams({
-        title,
-        subtitle: 'Revenue Operations Project',
-      }).toString()}`,
+      xmlSafeUrl(
+        `${baseUrl}/api/og?${new URLSearchParams({
+          title,
+          subtitle: 'Revenue Operations Project',
+        }).toString()}`
+      ),
     ],
   }))
 
@@ -144,7 +154,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
           post.updatedAt?.toISOString() || post.publishedAt?.toISOString() || fallbackDate,
         changeFrequency: 'monthly' as const,
         priority: 0.7,
-        images: [featuredAbsolute],
+        images: [xmlSafeUrl(featuredAbsolute)],
       }
     })
   } catch (error) {


### PR DESCRIPTION
## Summary

CRITICAL — sitemap parse failure caught by browser-agent re-validation. GSC reported "Sitemap can be read, but has errors → Parsing error (1) → Discovered pages: 0" on the resubmitted /sitemap.xml.

## Root cause

Next.js's \`MetadataRoute.Sitemap\` serializer does NOT XML-escape \`&\` characters in the \`images[]\` URL strings before emitting them inside \`<image:loc>\`. URLs constructed via \`URLSearchParams.toString()\` contain literal \`&\` between query params (e.g., \`?title=X&subtitle=Y\`), which Google's strict XML parser rejects on first occurrence — aborting the entire sitemap parse.

Affected URLs:
- 14 project /api/og?title=...&subtitle=... entries
- 21 blog featuredImage URLs from images.unsplash.com (\`?w=1200&h=630&fit=crop&q=80\`)
= all 35 \`<image:image>\` blocks in the sitemap.

Verified directly via MCP fetch — line 42 of the live sitemap reads:
\`<image:loc>https://richardwhudsonjr.com/api/og?title=Revenue+Operations+Dashboard&subtitle=Revenue+Operations+Project</image:loc>\`

That bare \`&subtitle=\` is invalid XML.

## Fix

Tiny \`xmlSafeUrl\` helper that replaces \`&\` → \`&amp;\` before passing each URL to the \`images[]\` array. Next.js emits the string as-is into the XML element value, so the encoded form survives serialization. Browsers/parsers un-escape back to the working URL on read.

## Impact

After deploy + GSC sitemap re-fetch:
- Discovered URLs jumps from 0 → ~46
- Google can finally crawl the 21 blog posts + 5 categories + 14 project pages with their image extensions
- Unblocks all the GSC actions (Resubmit Sitemap, Validate Fix, Request Indexing) that were paused

## Verification

- [x] \`bun run typecheck\` clean
- [ ] After deploy: live sitemap shows \`&amp;\` (encoded) in every \`<image:loc>\`
- [ ] After deploy: re-resubmit /sitemap.xml in GSC → expect Status = Success, Discovered URLs = ~46

[hudsor01]