### PR TITLE
fix(blog): hot-fix /blog/[slug] 500 regression — RelatedPosts try/catch

### DIFF
--- a/src/components/blog/related-posts.tsx
+++ b/src/components/blog/related-posts.tsx
@@ -1,6 +1,9 @@
 import Link from 'next/link'
 import { db } from '@/lib/db'
+import { createContextLogger } from '@/lib/logger'
 import { selectRelatedPosts, type RelatedPostInput } from './related-posts-utils'
+
+const logger = createContextLogger('RelatedPosts')
 
 interface RelatedPostsProps {
   currentSlug: string
@@ -11,23 +14,46 @@ interface RelatedPostsProps {
 export async function RelatedPosts({ currentSlug, currentTags, limit = 3 }: RelatedPostsProps) {
   const safeLimit = Math.min(limit, 3)
 
-  const posts = await db.blogPost.findMany({
-    where: { status: 'PUBLISHED', deletedAt: null, NOT: { slug: currentSlug } },
-    select: {
-      slug: true,
-      title: true,
-      excerpt: true,
-      publishedAt: true,
-      tags: { select: { tag: { select: { name: true } } } },
-    },
-    orderBy: { publishedAt: 'desc' },
-    take: 50,
-  })
+  // Wrapped in try/catch so a failure in this widget never crashes the whole
+  // blog-post page render (Next.js Server Components rethrow uncaught errors
+  // into the parent error boundary, which surfaces as HTTP 500 to the user).
+  // RelatedPosts is a "nice-to-have" widget — DB hiccup shouldn't take down
+  // the post.
+  type PostRow = {
+    slug: string
+    title: string
+    excerpt: string | null
+    publishedAt: Date | null
+    tags: { tag: { name: string } }[]
+  }
+  let posts: PostRow[]
+  try {
+    posts = await db.blogPost.findMany({
+      where: { status: 'PUBLISHED', deletedAt: null, NOT: { slug: currentSlug } },
+      select: {
+        slug: true,
+        title: true,
+        excerpt: true,
+        publishedAt: true,
+        tags: { select: { tag: { select: { name: true } } } },
+      },
+      orderBy: { publishedAt: 'desc' },
+      take: 50,
+    })
+  } catch (error) {
+    logger.error(
+      'RelatedPosts DB query failed; rendering nothing',
+      error instanceof Error ? error : new Error(String(error)),
+      { currentSlug }
+    )
+    return null
+  }
 
   const candidates: (RelatedPostInput & { excerpt: string | null })[] = posts.map((p) => ({
     slug: p.slug,
     title: p.title,
-    tags: p.tags.map((t) => t.tag.name),
+    // Defensive against missing tag rows (orphaned PostTag with deleted Tag)
+    tags: (p.tags ?? []).map((t) => t?.tag?.name).filter((n): n is string => !!n),
     publishedAt: p.publishedAt?.toISOString() ?? '1970-01-01',
     excerpt: p.excerpt,
   }))


### PR DESCRIPTION
## Summary

PRODUCTION REGRESSION: every \`/blog/[slug]\` returns HTTP 500.

## Discovery

Browser-agent caught it during GSC URL Inspection live test on URL #3 of 4:
> "URL is not available to Google → Page cannot be indexed: Server error (5xx)"

Verified with direct curl on 3 different slugs — all 500. /blog index 200, /blog/category/* 200, /api/blog/[slug] 200, / 200, /projects/* 200.

Vercel runtime logs confirm \`[Error: An error occurred i...\` (truncated) on every /blog/[slug] request.

## Most likely cause

The RelatedPosts widget added in PR #69 (commit 814f83b) is the only new addition to /blog/[slug] page. Hits the DB with a nested PostTag→Tag select. Vercel logs truncate the actual error message, so root cause unclear.

## Hot-fix approach

Wrap the RelatedPosts DB query + render in try/catch. Widget silently returns null on failure with a logger.error call (routed to Sentry for visibility). Two outcomes:

| Outcome | Means |
|---|---|
| /blog/[slug] now 200 with no related-posts section visible | RelatedPosts WAS the cause — Sentry will tell us the underlying error (currentSlug context included) |
| /blog/[slug] still 500 | something else broke; RelatedPosts is now defensively safe regardless |

Either way, this unblocks the 21 blog post URLs from a 5xx storm in GSC.

## Defensive bonus

Also added optional-chaining + filter on \`t.tag.name\` access to handle orphaned PostTag rows (deleted Tag) without throwing.

## Verification

- [x] \`bun run typecheck\` clean
- [x] \`bunx vitest run\` 181/181 pass

## Test plan

- [ ] CI passes
- [ ] After deploy: \`curl -s -o /dev/null -w '%{http_code}' https://richardwhudsonjr.com/blog/lead-scoring-models-that-actually-work\` returns 200
- [ ] Check Sentry for \`RelatedPosts DB query failed\` events to identify root cause
- [ ] Re-run GSC URL Inspection on the 5xx blog URL — should now pass live test

[hudsor01]