### PR TITLE
fix(blog): use isomorphic-dompurify in blog-post-article (SSR-safe)

### DIFF
--- a/src/app/blog/_components/blog-post-article.tsx
+++ b/src/app/blog/_components/blog-post-article.tsx
@@ -9,7 +9,12 @@ import { useTheme } from 'next-themes'
 import { cn } from '@/lib/utils'
 import { escapeHtml } from '@/lib/sanitization'
 import { ContentType } from '@/generated/prisma/browser'
-import DOMPurify from 'dompurify'
+// MUST be isomorphic-dompurify, NOT plain dompurify. This is a 'use client'
+// component, but Next.js still server-renders the initial HTML — the bare
+// `dompurify` package is browser-only (needs window/document) and throws on
+// the server, which surfaces as 500 on every /blog/[slug] page render.
+// isomorphic-dompurify wraps it with a JSDOM window for SSR safety.
+import DOMPurify from 'isomorphic-dompurify'
 import { createContextLogger } from '@/lib/logger'
 import { TIMING_CONSTANTS } from '@/lib/ui-thresholds'
 


### PR DESCRIPTION
## ROOT CAUSE FOUND

PR #75 hot-fix wrapped RelatedPosts in try/catch — pages still 500'd. No "RelatedPosts DB query failed" log entries appeared, confirming failure happens BEFORE RelatedPosts renders.

Bisected to \`src/app/blog/_components/blog-post-article.tsx:12\`:
\`\`\`ts
import DOMPurify from 'dompurify'
\`\`\`

The bare \`dompurify\` package is browser-only — it needs window/document at \`sanitize()\` call time. \`'use client'\` directive moves client-side bundling/hydration, but Next.js still renders the initial HTML on the server. \`DOMPurify.sanitize(html, config)\` throws with no window on Node.js, surfacing as 500 on every blog-post page render.

## Why it surfaced TODAY

Pre-Neon-DB-fix, blog posts didn't exist in production. \`getBlogPost\` returned null → \`notFound()\` → 404 page (article never rendered). Once 21 published posts came online via today's \`prisma migrate deploy\`, the article actually rendered and hit the dormant SSR bug.

## Fix

Drop-in swap to \`isomorphic-dompurify\` (already in package.json deps; \`src/lib/sanitization.ts:34\` already uses it for the same SSR-safety reason). Same DOMPurify API, wraps with a JSDOM window for SSR.

## Verification

- [x] \`bun run typecheck\` clean
- [x] \`bunx vitest run\` 181/181 pass
- [ ] After deploy: \`curl -s -o /dev/null -w '%{http_code}' https://richardwhudsonjr.com/blog/lead-scoring-models-that-actually-work\` returns 200
- [ ] Re-run GSC URL Inspection on the previously-5xx blog URL

[hudsor01]