### PR TITLE
fix(seo): force-dynamic on dynamic routes for reliable HTTP 404

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -13,11 +13,20 @@ import type { BlogPostData } from '@/types/api'
 import { db } from '@/lib/db'
 import { blogPosts } from '@/db/schema'
 
-// ISR with 60s revalidation, matching /projects/[slug]/page.tsx:7. The
-// previous `force-dynamic` was a workaround for the recursive
-// src/app/not-found.tsx that called notFound() inside itself — fixed in
-// PR #78, so static rendering works again.
-export const revalidate = 60
+// Force runtime rendering. notFound() inside Next.js 16's ISR-rendered
+// Server Components doesn't propagate HTTP 404 status to Vercel — the
+// rendered template ships with HTTP 200, which Google flags as Soft 404
+// in Search Console. force-dynamic skips the ISR pipeline so notFound()
+// reliably yields HTTP 404 from the runtime render path.
+//
+// Performance: s-maxage=60 + stale-while-revalidate=86400 in next.config.js
+// caches successful responses at the CDN, so real-slug requests are still
+// served without function invocation after the first hit. Net effect for
+// real slugs is nearly identical to ISR; the difference is that fake
+// slugs now correctly emit HTTP 404 instead of 200-with-body.
+//
+// Upstream tracking: https://github.com/vercel/next.js/issues/79465
+export const dynamic = 'force-dynamic'
 
 const logger = createContextLogger('BlogPost')
 

--- a/src/app/blog/category/[slug]/page.tsx
+++ b/src/app/blog/category/[slug]/page.tsx
@@ -14,6 +14,12 @@ import { db } from '@/lib/db'
 import { blogPosts, categories } from '@/db/schema'
 import { createContextLogger } from '@/lib/logger'
 
+// Force runtime rendering — see /blog/[slug]/page.tsx for the rationale.
+// notFound() inside ISR-rendered Server Components ships HTTP 200 with a
+// 404 body, which Google flags as Soft 404. force-dynamic gets reliable
+// HTTP 404 for unknown categories.
+export const dynamic = 'force-dynamic'
+
 const logger = createContextLogger('BlogCategoryPage')
 
 interface BlogCategoryPageProps {

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -3,8 +3,12 @@ import { notFound } from 'next/navigation'
 import { getProjects, getProject } from '@/lib/projects'
 import ProjectDetailClientBoundary from './_components/project-detail-client-boundary'
 
-// Official Next.js 16 Pattern: Static generation with ISR
-export const revalidate = 3600 // Revalidate every hour
+// Force runtime rendering. notFound() inside Next.js 16's ISR-rendered
+// Server Components doesn't propagate HTTP 404 — fake project slugs were
+// 500-ing instead of returning 404. force-dynamic + s-maxage=60 CDN
+// caching gets the same performance for real slugs while fixing 404s
+// for unknown ones. Upstream: https://github.com/vercel/next.js/issues/79465
+export const dynamic = 'force-dynamic'
 
 interface ProjectPageProps {
   params: Promise<{


### PR DESCRIPTION
## Summary

Follow-up to PR #78. Three dynamic routes still had wrong HTTP status codes for unknown slugs:

| Route | Before | After |
|---|---|---|
| `/blog/[slug]` (fake slug) | 200 with not-found body (soft-404) | **404** |
| `/blog/category/[slug]` (fake slug) | 200 with not-found body | **404** |
| `/projects/[slug]` (fake slug) | **500** | **404** |

All three stem from [vercel/next.js#79465](https://github.com/vercel/next.js/issues/79465) — `notFound()` inside ISR-rendered Server Components doesn't propagate HTTP 404 to Vercel.

## Fix

`export const dynamic = 'force-dynamic'` on all three routes. Skips the ISR pipeline; `notFound()` reliably yields HTTP 404 from the runtime render path.

## Performance

Minimal impact. `next.config.js` already sets:
```
Cache-Control: s-maxage=60, stale-while-revalidate=86400
CDN-Cache-Control: max-age=3600
```
on `/blog/*` and `/projects/*`. Successful renders are cached at the Vercel edge. Real slugs still serve without function invocation after the first hit per 60s window. Net effect is comparable to ISR for users.

## What's removed

- `export const revalidate = 60` from `/blog/[slug]` (now dead under force-dynamic)
- `export const revalidate = 3600` from `/projects/[slug]` (same)

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` — 181 tests pass
- [ ] Preview: real `/blog/lead-scoring-models-that-actually-work` → 200
- [ ] Preview: fake `/blog/zzz-fake-slug-test` → 404
- [ ] Preview: real `/projects/forecast-pipeline-intelligence` → 200
- [ ] Preview: fake `/projects/zzz-fake-project` → 404
- [ ] Preview: fake `/blog/category/zzz-fake-cat` → 404
- [ ] Preview: `/random-zzz-page` (root not-found) → 404 (unchanged)
- [ ] After merge: GSC re-validates Soft 404 + Server error (5xx) buckets cleanly

[hudsor01]