### PR TITLE
fix(api): hide DRAFT/SCHEDULED posts from public callers

### DIFF
--- a/src/app/api/blog/[slug]/route.ts
+++ b/src/app/api/blog/[slug]/route.ts
@@ -5,6 +5,7 @@ import { createContextLogger } from '@/lib/logger'
 import { db } from '@/lib/db'
 import { authors, blogPosts, categories, postTags, tags, type NewBlogPost } from '@/db/schema'
 import { validateCSRFOrRespond } from '@/lib/api-csrf'
+import { isAdminRequest } from '@/lib/api-admin-auth'
 import { transformToBlogPostData, createErrorResponse } from '@/lib/api-blog'
 
 const logger = createContextLogger('SlugAPI')
@@ -17,7 +18,7 @@ const POST_WITH_RELATIONS = {
   },
 } as const
 
-export async function GET(_request: NextRequest, context: { params: Promise<{ slug: string }> }) {
+export async function GET(request: NextRequest, context: { params: Promise<{ slug: string }> }) {
   try {
     const { slug } = await context.params
 
@@ -34,17 +35,28 @@ export async function GET(_request: NextRequest, context: { params: Promise<{ sl
       return NextResponse.json(createErrorResponse('Blog post not found'), { status: 404 })
     }
 
-    // Fire-and-forget view count increment
-    db.update(blogPosts)
-      .set({ viewCount: sql`${blogPosts.viewCount} + 1` })
-      .where(eq(blogPosts.id, post.id))
-      .catch((err) =>
-        logger.error(
-          'Failed to increment view count',
-          err instanceof Error ? err : new Error(String(err)),
-          { slug: post.slug, postId: post.id }
+    // Hide DRAFT/SCHEDULED/ARCHIVED/DELETED posts (and soft-deleted ones) from
+    // public callers. Admin-token holders bypass the gate so the future admin
+    // UI can preview unpublished content. Same 404 response so anonymous
+    // callers can't differentiate "doesn't exist" from "exists but not public".
+    const isPublic = post.status === 'PUBLISHED' && post.deletedAt === null
+    if (!isPublic && !isAdminRequest(request)) {
+      return NextResponse.json(createErrorResponse('Blog post not found'), { status: 404 })
+    }
+
+    // Fire-and-forget view count increment (only for actually-public reads)
+    if (isPublic) {
+      db.update(blogPosts)
+        .set({ viewCount: sql`${blogPosts.viewCount} + 1` })
+        .where(eq(blogPosts.id, post.id))
+        .catch((err) =>
+          logger.error(
+            'Failed to increment view count',
+            err instanceof Error ? err : new Error(String(err)),
+            { slug: post.slug, postId: post.id }
+          )
         )
-      )
+    }
 
     const response: ApiResponse<BlogPostData> = {
       data: transformToBlogPostData(post),
@@ -53,7 +65,11 @@ export async function GET(_request: NextRequest, context: { params: Promise<{ sl
 
     return NextResponse.json(response, {
       headers: {
-        'Cache-Control': 'public, max-age=300, s-maxage=600',
+        // Don't cache admin-only views in public/CDN tier — Cache-Control
+        // private prevents leaking unpublished content via shared cache.
+        'Cache-Control': isPublic
+          ? 'public, max-age=300, s-maxage=600'
+          : 'private, no-store, max-age=0, must-revalidate',
       },
     })
   } catch (error) {

--- a/src/app/api/blog/route.ts
+++ b/src/app/api/blog/route.ts
@@ -12,6 +12,7 @@ import type {
 } from '@/types/api'
 import { checkRateLimitOrRespond, RateLimitPresets } from '@/lib/api-rate-limit'
 import { validateCSRFOrRespond } from '@/lib/api-csrf'
+import { isAdminRequest } from '@/lib/api-admin-auth'
 import { parsePaginationParams, createPaginationMeta } from '@/lib/api-pagination'
 import {
   transformToBlogPostData,
@@ -49,6 +50,7 @@ export async function GET(request: NextRequest) {
 
     // Parse filters
     const filters: BlogPostFilters = {}
+    const isAdmin = isAdminRequest(request)
 
     if (searchParams.get('status')) {
       filters.status = searchParams.get('status')!
@@ -75,6 +77,13 @@ export async function GET(request: NextRequest) {
         from: searchParams.get('dateFrom')!,
         to: searchParams.get('dateTo')!,
       }
+    }
+
+    // Public callers see only PUBLISHED, non-soft-deleted posts. Admin-token
+    // holders can pass `?status=DRAFT` (etc.) to see other states; if they
+    // don't pass `status`, they see everything (legacy admin behavior).
+    if (!isAdmin && !filters.status && filters.published === undefined) {
+      filters.published = true
     }
 
     // Parse sorting

--- a/src/app/api/seed/route.ts
+++ b/src/app/api/seed/route.ts
@@ -1,32 +1,17 @@
 import { type NextRequest, NextResponse } from 'next/server'
-import { timingSafeEqual } from 'node:crypto'
 import { count, eq } from 'drizzle-orm'
 import { db } from '@/lib/db'
 import { authors, blogPosts, categories } from '@/db/schema'
 import { logger } from '@/lib/logger'
 import { env } from '@/lib/env-validation'
-
-function isAuthorized(request: NextRequest): boolean {
-  const expected = env.ADMIN_API_TOKEN
-  if (!expected) return false
-
-  const header = request.headers.get('authorization') ?? ''
-  const match = header.match(/^Bearer\s+(.+)$/i)
-  if (!match) return false
-
-  const provided = (match[1] ?? '').trim()
-  const a = Buffer.from(provided)
-  const b = Buffer.from(expected)
-  if (a.length !== b.length) return false
-  return timingSafeEqual(a, b)
-}
+import { isAdminRequest } from '@/lib/api-admin-auth'
 
 export async function POST(request: NextRequest) {
   if (env.NODE_ENV === 'production' && env.ALLOW_SEED_IN_PRODUCTION !== 'true') {
     return NextResponse.json({ success: false, error: 'Not found' }, { status: 404 })
   }
 
-  if (!isAuthorized(request)) {
+  if (!isAdminRequest(request)) {
     logger.warn('Unauthorized seed attempt', { route: 'api/seed' })
     return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 })
   }

--- a/src/lib/api-admin-auth.ts
+++ b/src/lib/api-admin-auth.ts
@@ -1,0 +1,33 @@
+import 'server-only'
+import { timingSafeEqual } from 'node:crypto'
+import { env } from '@/lib/env-validation'
+
+/**
+ * Constant-time check for the admin bearer token.
+ *
+ * Returns true iff the request carries `Authorization: Bearer <ADMIN_API_TOKEN>`
+ * AND the token matches `env.ADMIN_API_TOKEN` (compared with timingSafeEqual to
+ * avoid leaking the secret through response timing).
+ *
+ * Returns false if `ADMIN_API_TOKEN` is unset, the header is missing or
+ * malformed, or the token doesn't match. Never throws.
+ *
+ * Used by:
+ *   - /api/seed (gate the whole route)
+ *   - /api/blog GET (admin can pass ?status=DRAFT etc.; public callers see only PUBLISHED)
+ *   - /api/blog/[slug] GET (admin can read DRAFT/SCHEDULED/ARCHIVED; public sees 404)
+ */
+export function isAdminRequest(request: Request): boolean {
+  const expected = env.ADMIN_API_TOKEN
+  if (!expected) return false
+
+  const header = request.headers.get('authorization') ?? ''
+  const match = header.match(/^Bearer\s+(.+)$/i)
+  if (!match) return false
+
+  const provided = (match[1] ?? '').trim()
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}

--- a/src/lib/api-blog.ts
+++ b/src/lib/api-blog.ts
@@ -1,4 +1,18 @@
-import { and, asc, desc, eq, gte, ilike, inArray, lte, ne, or, sql, type SQL } from 'drizzle-orm'
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  gte,
+  ilike,
+  inArray,
+  isNull,
+  lte,
+  ne,
+  or,
+  sql,
+  type SQL,
+} from 'drizzle-orm'
 import { db } from '@/lib/db'
 import {
   blogPosts,
@@ -150,9 +164,15 @@ export function buildBlogWhereClause(filters?: BlogPostFilters): SQL | undefined
   }
 
   if (filters.published !== undefined) {
-    conditions.push(
-      filters.published ? eq(blogPosts.status, 'PUBLISHED') : ne(blogPosts.status, 'PUBLISHED')
-    )
+    if (filters.published) {
+      // Public visibility: PUBLISHED status AND not soft-deleted. Both
+      // conditions are required so that an admin who soft-deletes a post via
+      // (future) admin UI immediately removes it from public listings.
+      conditions.push(eq(blogPosts.status, 'PUBLISHED'))
+      conditions.push(isNull(blogPosts.deletedAt))
+    } else {
+      conditions.push(ne(blogPosts.status, 'PUBLISHED'))
+    }
   }
 
   if (conditions.length === 0) return undefined


### PR DESCRIPTION
## Summary

`/api/blog` (list) and `/api/blog/[slug]` (detail) GET endpoints leak DRAFT and SCHEDULED posts to anonymous callers. Discovered via the GSC browser-agent run today — the agent flagged two real, API-listed slugs as "Soft 404" because the page render correctly hides them but the API was advertising them as public.

## Confirmed leak (current production)

```
$ curl -s 'https://richardwhudsonjr.com/api/blog?limit=20' \
    | jq '.data | map(.status) | group_by(.) | map({(.[0]): length}) | add'
{"DRAFT": 1, "SCHEDULED": 1, "PUBLISHED": 18}

$ curl -s 'https://richardwhudsonjr.com/api/blog/future-revenue-operations-technology' \
    | jq '.data.status'
"DRAFT"
```

Two specific drafts exposed today:
- `optimizing-customer-lifetime-value-calculations` (SCHEDULED)
- `future-revenue-operations-technology` (DRAFT)

Anyone with the slug — or willing to guess — could read full unpublished content via the API.

## Why this wasn't caught before

The `/blog/[slug]` Server Component page filters `status='PUBLISHED'` correctly, so end-users on the website never saw drafts. The leak is API-only, and the API tier had no auth gate or default status filter. This was inherited from the original Prisma routes; the Drizzle migration carried it forward unchanged.

## Fix

1. **New `src/lib/api-admin-auth.ts`** — `isAdminRequest()` extracted from `/api/seed/route.ts`. Constant-time bearer check against `ADMIN_API_TOKEN`.

2. **`/api/blog` GET** — anonymous callers default to `published=true` (which now expands to `status='PUBLISHED' AND deletedAt IS NULL` in `buildBlogWhereClause`). Admin-token holders see all statuses or can pass `?status=DRAFT` explicitly.

3. **`/api/blog/[slug]` GET** — anonymous callers requesting a non-published or soft-deleted slug get HTTP 404 (same response as missing slug, so callers can't differentiate). Admin tokens bypass. View count only increments on public reads. `Cache-Control: private, no-store` for admin-only views so CDN/shared caches can't leak.

4. **`/api/seed`** — refactored to import the shared `isAdminRequest` instead of the inlined helper.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` — 181 tests pass
- [ ] Preview: `curl /api/blog?limit=20` returns only `PUBLISHED` posts (no DRAFT/SCHEDULED)
- [ ] Preview: `curl /api/blog/<draft-slug>` → 404 without auth
- [ ] Preview: `curl -H "Authorization: Bearer <ADMIN_API_TOKEN>" /api/blog/<draft-slug>` → 200 with full data (admin path)
- [ ] After merge: GSC live test on `/blog/future-revenue-operations-technology` should show "URL is unknown to Google" or similar (not Soft 404)

[hudsor01]