### PR TITLE
fix: address all 8 browser audit findings (7 code fixes + 1 verified-already-fixed)

### DIFF
--- a/e2e/audit-regressions.spec.ts
+++ b/e2e/audit-regressions.spec.ts
@@ -3,18 +3,26 @@ import { test, expect } from '@playwright/test'
 /**
  * Audit Regression Tests — Canonical Survival Check
  *
- * Focused regressions for the 5 audit fixes that landed during the
- * audit/page-interactivity work. Some assertions are intentionally
- * duplicated from the per-page specs (homepage / contact / projects-detail
- * / security-headers); this file is the single canonical "did the audit
- * fixes survive?" gate. If a future change breaks any one of these, we
- * want it loud and obvious — not buried in a per-feature suite.
+ * Focused regressions for every audit fix that has shipped to main.
+ * Assertions are intentionally duplicated from per-page specs; this
+ * file is the single canonical "did the audit fixes survive?" gate.
  *
+ * Interactivity audit (audit/page-interactivity, PR #87/#88):
  *   #1 /projects/revenue-kpi has no timeframe pills
  *   #2 /about button text is "View Resume" (not "Download Resume")
  *   #3 Homepage Proven Results metrics reach non-zero values within 5s
  *   #4 GET /api/generate-resume-pdf returns 404 (route deleted)
  *   #5 /contact noscript fallback visible when JS is disabled
+ *
+ * Browser audit (PR #96):
+ *   #6 /blog/<bad>, /projects/<bad>, /blog/category/<bad> return HTTP 404
+ *   #7 Tab clicks on /projects/cac-unit-economics push ?tab= to URL
+ *   #8 No horizontal page overflow at viewport <=1024px on project pages
+ *   #9 Each blog post page has exactly one <h1>
+ *  #10 /blog post-card titles render as <h2> (heading outline coverage)
+ *  #11 Project pages have <h2> between page <h1> and any <h3> (no skipped level)
+ *  #12 Homepage hero <h1> has opacity 1 immediately after navigation
+ *  #13 /nonexistent document.title starts with "404"
  */
 
 test.describe('Audit regressions', () => {
@@ -95,5 +103,129 @@ test.describe('Audit regressions', () => {
     } finally {
       await context.close()
     }
+  })
+
+  // ──────────────────────────────────────────────────────────────────
+  // Browser audit (PR #96)
+  // ──────────────────────────────────────────────────────────────────
+
+  test('#6 unknown slug routes return HTTP 404 (no soft-404)', async ({ page }) => {
+    // ProjectPage / BlogPost / BlogCategory call notFound() when the slug
+    // is unknown; force-dynamic on the route ensures HTTP 404 propagates
+    // (the prior soft-404 returned 200 with the themed body, which Google
+    // Search Console flagged).
+    for (const path of [
+      '/blog/this-slug-does-not-exist',
+      '/projects/this-slug-does-not-exist',
+      '/blog/category/this-slug-does-not-exist',
+    ]) {
+      const response = await page.request.get(path)
+      expect(response.status(), `${path} should return 404`).toBe(404)
+    }
+  })
+
+  test('#7 tab clicks on /projects/cac-unit-economics push ?tab= to URL', async ({ page }) => {
+    await page.goto('/projects/cac-unit-economics')
+    await page.waitForLoadState('networkidle')
+
+    // Initial URL has no tab param. Clicking the Channels tab via the
+    // ProjectPageLayout timeframe-selector buttons should call nuqs's
+    // setActiveTab → updates URL.
+    const channelsButton = page.getByRole('button', { name: /^channels$/i }).first()
+    await channelsButton.click()
+
+    await page.waitForFunction(
+      () => new URL(window.location.href).searchParams.get('tab') === 'channels',
+      { timeout: 3000 }
+    )
+  })
+
+  test('#8 no horizontal page overflow at <=1024px viewport on project pages', async ({
+    browser,
+  }) => {
+    // Audit found scrollWidth > innerWidth on every project detail page
+    // because the absolute decorative blurs in ProjectPageLayout escaped
+    // their container (parent had overflow-hidden but no `relative`).
+    const context = await browser.newContext({ viewport: { width: 1000, height: 800 } })
+    const page = await context.newPage()
+    try {
+      await page.goto('/projects/cac-unit-economics')
+      await page.waitForLoadState('networkidle')
+
+      const overflows = await page.evaluate(() => {
+        return document.documentElement.scrollWidth > window.innerWidth
+      })
+      expect(overflows, 'project page must not overflow horizontally at 1000px').toBe(false)
+    } finally {
+      await context.close()
+    }
+  })
+
+  test('#9 each blog post page has exactly one <h1>', async ({ page }) => {
+    // The audit found a duplicate <h1> on a blog post because the body
+    // content shipped a literal <h1> matching the page title. The render
+    // path now demotes any in-body <h1> to <h2>.
+    await page.goto('/blog')
+    await page.waitForLoadState('networkidle')
+
+    // Visit the first published post link to verify the article template.
+    const firstPostLink = page.locator('a[href^="/blog/"]:not([href="/blog"])').first()
+    const href = await firstPostLink.getAttribute('href')
+    if (!href) test.skip(true, 'No blog posts present in this environment')
+
+    await page.goto(href!)
+    await page.waitForLoadState('networkidle')
+
+    const h1Count = await page.locator('h1').count()
+    expect(h1Count, 'blog post page should have exactly one <h1>').toBe(1)
+  })
+
+  test('#10 /blog and /blog/category cards render <h2> per card', async ({ page }) => {
+    // Audit found post titles rendered as styled <div>s instead of <h2>,
+    // breaking screen-reader heading navigation. CardTitle is now
+    // polymorphic; consumers pass `as="h2"` for the post-card title.
+    await page.goto('/blog')
+    await page.waitForLoadState('networkidle')
+
+    // The page should have multiple <h2>s (one per post card). The exact
+    // count varies as posts are published, but >= 1 is the contract.
+    const h2Count = await page.locator('main h2').count()
+    expect(h2Count, '/blog should have at least one <h2> from post cards').toBeGreaterThan(0)
+  })
+
+  test('#11 project pages have <h2> between page <h1> and any <h3>', async ({ page }) => {
+    // SectionCard's title was h3, producing h1 → h3 outlines. Now h2.
+    await page.goto('/projects/cac-unit-economics')
+    await page.waitForLoadState('networkidle')
+
+    const h1Count = await page.locator('main h1').count()
+    const h2Count = await page.locator('main h2').count()
+    expect(h1Count).toBeGreaterThanOrEqual(1)
+    expect(h2Count, 'project page must have at least one <h2> for outline continuity').toBeGreaterThan(0)
+  })
+
+  test('#12 homepage hero <h1> has opacity 1 immediately after navigation', async ({
+    page,
+  }) => {
+    // Audit found the hero rendered at opacity 0 for 2-6s while the
+    // mounted/in-view gate resolved. Above-the-fold gates removed.
+    await page.goto('/')
+    await page.waitForLoadState('domcontentloaded')
+
+    const heroOpacity = await page
+      .locator('h1')
+      .filter({ hasText: /transforming/i })
+      .first()
+      .evaluate((el) => parseFloat(window.getComputedStyle(el).opacity))
+
+    expect(heroOpacity, 'hero <h1> must be visible immediately').toBe(1)
+  })
+
+  test('#13 /nonexistent document.title starts with "404"', async ({ page }) => {
+    // Root not-found.tsx now exports metadata.title so the 404 page no
+    // longer inherits the homepage default title.
+    await page.goto('/nonexistent')
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page).toHaveTitle(/^404/)
   })
 })

--- a/src/app/blog/_components/blog-list.tsx
+++ b/src/app/blog/_components/blog-list.tsx
@@ -6,7 +6,7 @@ import { useQueryState } from 'nuqs'
 import type { BlogPostData, BlogCategoryData } from '@/types/api'
 import { BlogTagFilter } from './blog-tag-filter'
 import { InlineMarkdown } from './inline-markdown'
-import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
+import { Card, CardHeader, CardDescription, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 
 interface BlogListProps {
@@ -120,9 +120,12 @@ export function BlogList({ initialPosts, initialCategories }: BlogListProps) {
                       ))}
                     </div>
                   )}
-                  <CardTitle className="text-xl line-clamp-2 group-hover:text-primary transition-colors">
+                  <h2
+                    data-slot="card-title"
+                    className="leading-none font-semibold text-xl line-clamp-2 group-hover:text-primary transition-colors"
+                  >
                     <InlineMarkdown value={post.title} />
-                  </CardTitle>
+                  </h2>
                   <CardDescription className="line-clamp-3">
                     {post.excerpt ? <InlineMarkdown value={post.excerpt} /> : ''}
                   </CardDescription>

--- a/src/app/blog/_components/blog-list.tsx
+++ b/src/app/blog/_components/blog-list.tsx
@@ -6,7 +6,7 @@ import { useQueryState } from 'nuqs'
 import type { BlogPostData, BlogCategoryData } from '@/types/api'
 import { BlogTagFilter } from './blog-tag-filter'
 import { InlineMarkdown } from './inline-markdown'
-import { Card, CardHeader, CardDescription, CardContent } from '@/components/ui/card'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 
 interface BlogListProps {
@@ -120,12 +120,12 @@ export function BlogList({ initialPosts, initialCategories }: BlogListProps) {
                       ))}
                     </div>
                   )}
-                  <h2
-                    data-slot="card-title"
-                    className="leading-none font-semibold text-xl line-clamp-2 group-hover:text-primary transition-colors"
+                  <CardTitle
+                    as="h2"
+                    className="text-xl line-clamp-2 group-hover:text-primary transition-colors"
                   >
                     <InlineMarkdown value={post.title} />
-                  </h2>
+                  </CardTitle>
                   <CardDescription className="line-clamp-3">
                     {post.excerpt ? <InlineMarkdown value={post.excerpt} /> : ''}
                   </CardDescription>

--- a/src/app/blog/_components/blog-post-article.tsx
+++ b/src/app/blog/_components/blog-post-article.tsx
@@ -273,8 +273,15 @@ export function BlogPostArticle({
     })
   }
 
-  // Process content: parse markdown if needed, sanitize for non-markdown content
-  const processedContent = contentType === 'MARKDOWN' ? parseMarkdown(content) : content
+  // Process content: parse markdown if needed, sanitize for non-markdown content.
+  // For HTML/RICH_TEXT content, defensively demote any in-body <h1> to <h2> so
+  // we never get a double-h1 alongside the page title in blog-post-layout.tsx.
+  // (Markdown content is already handled by parseMarkdown above.) Browser audit
+  // surfaced this on `/blog/stop-using-generic-scripts...` — the post body
+  // shipped with a literal <h1> matching the page title.
+  const demoteH1 = (html: string): string =>
+    html.replace(/<h1(\s[^>]*)?>/gi, '<h2$1>').replace(/<\/h1>/gi, '</h2>')
+  const processedContent = contentType === 'MARKDOWN' ? parseMarkdown(content) : demoteH1(content)
   const sanitizedContent = sanitizeHtml(processedContent, DOMPURIFY_CONFIG)
 
   return (

--- a/src/app/blog/category/[slug]/page.tsx
+++ b/src/app/blog/category/[slug]/page.tsx
@@ -7,7 +7,7 @@ import Image from 'next/image'
 import { Navbar } from '@/components/layout/navbar'
 import { BlogCategoryJsonLd } from '@/components/seo/blog-json-ld'
 import { BreadcrumbListJsonLd } from '@/components/seo/json-ld/breadcrumb-json-ld'
-import { Card, CardHeader, CardDescription, CardContent } from '@/components/ui/card'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { and, desc, eq, isNull } from 'drizzle-orm'
 import { db } from '@/lib/db'
@@ -214,12 +214,12 @@ export default async function BlogCategoryPage({ params }: BlogCategoryPageProps
                               ))}
                             </div>
                           )}
-                          <h2
-                            data-slot="card-title"
-                            className="leading-none font-semibold text-xl line-clamp-2 group-hover:text-primary transition-colors"
+                          <CardTitle
+                            as="h2"
+                            className="text-xl line-clamp-2 group-hover:text-primary transition-colors"
                           >
                             {post.title}
-                          </h2>
+                          </CardTitle>
                           {post.excerpt && (
                             <CardDescription className="line-clamp-3">
                               {post.excerpt}

--- a/src/app/blog/category/[slug]/page.tsx
+++ b/src/app/blog/category/[slug]/page.tsx
@@ -7,7 +7,7 @@ import Image from 'next/image'
 import { Navbar } from '@/components/layout/navbar'
 import { BlogCategoryJsonLd } from '@/components/seo/blog-json-ld'
 import { BreadcrumbListJsonLd } from '@/components/seo/json-ld/breadcrumb-json-ld'
-import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
+import { Card, CardHeader, CardDescription, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { and, desc, eq, isNull } from 'drizzle-orm'
 import { db } from '@/lib/db'
@@ -214,9 +214,12 @@ export default async function BlogCategoryPage({ params }: BlogCategoryPageProps
                               ))}
                             </div>
                           )}
-                          <CardTitle className="text-xl line-clamp-2 group-hover:text-primary transition-colors">
+                          <h2
+                            data-slot="card-title"
+                            className="leading-none font-semibold text-xl line-clamp-2 group-hover:text-primary transition-colors"
+                          >
                             {post.title}
-                          </CardTitle>
+                          </h2>
                           {post.excerpt && (
                             <CardDescription className="line-clamp-3">
                               {post.excerpt}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1794,13 +1794,6 @@ input[type="reset"]:active,
 
 html {
   font-size: var(--font-size-base, 0.875rem);
-  /* Safety net: prevent horizontal page scroll caused by inner content
-     overflow (charts, badges, decorative blurs). Browser audit found
-     documentElement.scrollWidth > window.innerWidth at <=1024px on every
-     project detail page. TODO: identify specific overflowing components
-     (suspect: chart containers, decorative -right-32 background blurs)
-     and remove this rule once they're constrained at the source. */
-  overflow-x: hidden;
 }
 
 body {
@@ -1812,7 +1805,6 @@ body {
   font-feature-settings: 'rlig' 1, 'calt' 1;
   font-weight: var(--font-weight-regular, 400);
   line-height: var(--line-height-normal, 1.5);
-  overflow-x: hidden;
 }
 
 /* Headings use Playfair Display (serif) - loaded via Next.js */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1794,6 +1794,13 @@ input[type="reset"]:active,
 
 html {
   font-size: var(--font-size-base, 0.875rem);
+  /* Safety net: prevent horizontal page scroll caused by inner content
+     overflow (charts, badges, decorative blurs). Browser audit found
+     documentElement.scrollWidth > window.innerWidth at <=1024px on every
+     project detail page. TODO: identify specific overflowing components
+     (suspect: chart containers, decorative -right-32 background blurs)
+     and remove this rule once they're constrained at the source. */
+  overflow-x: hidden;
 }
 
 body {
@@ -1805,6 +1812,7 @@ body {
   font-feature-settings: 'rlig' 1, 'calt' 1;
   font-weight: var(--font-weight-regular, 400);
   line-height: var(--line-height-normal, 1.5);
+  overflow-x: hidden;
 }
 
 /* Headings use Playfair Display (serif) - loaded via Next.js */

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,5 +1,16 @@
+import type { Metadata } from 'next'
 import Link from 'next/link'
 import { Navbar } from '@/components/layout/navbar'
+
+// Override the root layout's homepage default title so 404 pages render
+// "404 — Page Not Found" instead of "Richard Hudson | Revenue Operations
+// Professional" (browser audit finding). robots.noindex prevents Google
+// from indexing the 404 body — segment-level not-found.tsx files already
+// set this; the global template did not.
+export const metadata: Metadata = {
+  title: '404 — Page Not Found',
+  robots: { index: false, follow: false },
+}
 
 // Rendered (with HTTP 404) whenever any page or layout calls `notFound()`
 // from next/navigation. The previous version called notFound() from inside

--- a/src/app/projects/cac-unit-economics/_components/CACPageContent.tsx
+++ b/src/app/projects/cac-unit-economics/_components/CACPageContent.tsx
@@ -1,5 +1,4 @@
 'use client'
-export const dynamic = 'force-static'
 
 import { TrendingUp, DollarSign, Target, Calculator } from 'lucide-react'
 import { useQueryState } from 'nuqs'

--- a/src/app/projects/churn-retention/_components/ChurnPageContent.tsx
+++ b/src/app/projects/churn-retention/_components/ChurnPageContent.tsx
@@ -1,5 +1,4 @@
 'use client'
-export const dynamic = 'force-static'
 
 import { useAnalyticsData } from '@/hooks/use-analytics-data'
 import { TrendingDown, Users, Activity, AlertCircle } from 'lucide-react'

--- a/src/app/projects/commission-optimization/_components/CommissionPageContent.tsx
+++ b/src/app/projects/commission-optimization/_components/CommissionPageContent.tsx
@@ -1,5 +1,4 @@
 'use client'
-export const dynamic = 'force-static'
 
 import { DollarSign, Percent, TrendingUp, Calculator } from 'lucide-react'
 import { useQueryState } from 'nuqs'

--- a/src/app/projects/customer-lifetime-value/_components/CLVPageContent.tsx
+++ b/src/app/projects/customer-lifetime-value/_components/CLVPageContent.tsx
@@ -1,5 +1,4 @@
 'use client'
-export const dynamic = 'force-static'
 
 import { DollarSign, Brain, Users, Calendar } from 'lucide-react'
 import { useQueryState } from 'nuqs'

--- a/src/app/projects/deal-funnel/_components/DealFunnelPageContent.tsx
+++ b/src/app/projects/deal-funnel/_components/DealFunnelPageContent.tsx
@@ -1,5 +1,4 @@
 'use client'
-export const dynamic = 'force-static'
 
 import { useState, useEffect, useRef } from 'react'
 import { DollarSign, Clock, Target, BarChart3 } from 'lucide-react'

--- a/src/app/projects/forecast-pipeline-intelligence/_components/ForecastPageContent.tsx
+++ b/src/app/projects/forecast-pipeline-intelligence/_components/ForecastPageContent.tsx
@@ -1,5 +1,4 @@
 'use client'
-export const dynamic = 'force-static'
 
 import { TrendingUp, AlertTriangle, Zap, BarChart3 } from 'lucide-react'
 

--- a/src/app/projects/lead-attribution/_components/LeadAttributionPageContent.tsx
+++ b/src/app/projects/lead-attribution/_components/LeadAttributionPageContent.tsx
@@ -1,5 +1,4 @@
 'use client'
-export const dynamic = 'force-static'
 
 import {
   TrendingUp,

--- a/src/app/projects/multi-channel-attribution/_components/MultiChannelPageContent.tsx
+++ b/src/app/projects/multi-channel-attribution/_components/MultiChannelPageContent.tsx
@@ -1,5 +1,4 @@
 'use client'
-export const dynamic = 'force-static'
 
 import { Target, Eye, Share2, DollarSign } from 'lucide-react'
 import { useQueryState } from 'nuqs'

--- a/src/app/projects/partner-performance/_components/PartnerPerformancePageContent.tsx
+++ b/src/app/projects/partner-performance/_components/PartnerPerformancePageContent.tsx
@@ -1,5 +1,4 @@
 'use client'
-export const dynamic = 'force-static'
 
 import { TrendingUp, Users, Target, DollarSign } from 'lucide-react'
 import { useQueryState } from 'nuqs'

--- a/src/app/projects/partnership-program-implementation/_components/PartnershipProgramPageContent.tsx
+++ b/src/app/projects/partnership-program-implementation/_components/PartnershipProgramPageContent.tsx
@@ -1,5 +1,4 @@
 'use client'
-export const dynamic = 'force-static'
 
 import { Zap, Clock, Settings, Users } from 'lucide-react'
 

--- a/src/app/projects/quota-territory-management/_components/QuotaTerritoryPageContent.tsx
+++ b/src/app/projects/quota-territory-management/_components/QuotaTerritoryPageContent.tsx
@@ -1,5 +1,4 @@
 'use client'
-export const dynamic = 'force-static'
 
 import { TrendingUp, Map as MapIcon, Database, Zap } from 'lucide-react'
 

--- a/src/app/projects/sales-enablement/_components/SalesEnablementPageContent.tsx
+++ b/src/app/projects/sales-enablement/_components/SalesEnablementPageContent.tsx
@@ -1,5 +1,4 @@
 'use client'
-export const dynamic = 'force-static'
 
 import { TrendingUp, Users, Zap, BookOpen } from 'lucide-react'
 

--- a/src/app/resume/_components/HeroHeader.tsx
+++ b/src/app/resume/_components/HeroHeader.tsx
@@ -9,7 +9,6 @@ import { FileDown, Mail, Globe, Eye } from 'lucide-react'
 import { Github, Linkedin } from '@/components/ui/brand-icons'
 
 interface HeroHeaderProps {
-  isHeroInView: boolean
   showPdf: boolean
   isDownloading: boolean
   onDownloadResume: () => void
@@ -17,16 +16,15 @@ interface HeroHeaderProps {
 }
 
 export function HeroHeader({
-  isHeroInView,
   showPdf,
   isDownloading,
   onDownloadResume,
   onToggleView,
 }: HeroHeaderProps) {
+  // Above-the-fold; no in-view opacity gate (browser audit found
+  // a 2-6s flash because IntersectionObserver hadn't fired yet).
   return (
-    <div
-      className={`text-center space-y-8 max-w-4xl mx-auto animate-fade-in-up ${isHeroInView ? 'opacity-100' : 'opacity-0'}`}
-    >
+    <div className="text-center space-y-8 max-w-4xl mx-auto animate-fade-in-up">
       <h1 className="text-4xl sm:text-5xl md:text-5xl lg:text-6xl font-bold tracking-tight mb-8">
         <span className="block hero-name-gradient">Richard Hudson</span>
       </h1>

--- a/src/app/resume/_components/resume-page-content.tsx
+++ b/src/app/resume/_components/resume-page-content.tsx
@@ -21,12 +21,10 @@ export default function ResumePageContent() {
   const [isDownloading, setIsDownloading] = useState(false)
   const [pdfUrl, setPdfUrl] = useState('')
 
-  // Refs for scroll animations
-  const heroRef = useRef(null)
+  // Refs for scroll animations (hero is above-the-fold; no in-view gate)
   const contentRef = useRef(null)
 
   // In-view hooks
-  const isHeroInView = useInView(heroRef, { once: true })
   const isContentInView = useInView(contentRef, { once: true })
 
   useEffect(() => {
@@ -69,9 +67,8 @@ export default function ResumePageContent() {
 
         <div className="relative max-w-7xl mx-auto px-6 lg:px-8 pt-24 pb-16 lg:pt-32 lg:pb-20 space-y-16">
           {/* Hero Header */}
-          <div ref={heroRef}>
+          <div>
             <HeroHeader
-              isHeroInView={isHeroInView}
               showPdf={showPdf}
               isDownloading={isDownloading}
               onDownloadResume={handleDownloadResume}

--- a/src/components/layout/home-page-content.tsx
+++ b/src/components/layout/home-page-content.tsx
@@ -15,16 +15,6 @@ import {
 import { Navbar } from '@/components/layout/navbar'
 import { NumberTicker } from '@/components/ui/number-ticker'
 import { Button } from '@/components/ui/button'
-import { useSyncExternalStore } from 'react'
-
-// Safe mounted check using useSyncExternalStore to avoid hydration mismatch
-function useMounted(): boolean {
-  return useSyncExternalStore(
-    () => () => {}, // No-op subscribe - we only care about initial state
-    () => true, // Client is always mounted
-    () => false // Server is never mounted
-  )
-}
 
 // Animated counter with visual impact
 function ImpactMetric({
@@ -66,8 +56,6 @@ function ImpactMetric({
 }
 
 export default function HomePageContent() {
-  const mounted = useMounted()
-
   return (
     <>
       <Navbar />
@@ -108,23 +96,27 @@ export default function HomePageContent() {
 
         <div className="w-full max-w-7xl mx-auto px-6 lg:px-8">
           <div className="grid lg:grid-cols-2 gap-12 lg:gap-20 items-center">
-            {/* Left Column - Content */}
-            <div
-              className={`space-y-8 transition-all duration-1000 ${mounted ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'}`}
-            >
+            {/*
+             * Left Column - Content
+             *
+             * Above-the-fold hero. Browser audit found a 2-6s
+             * opacity-flash on initial paint because the prior
+             * `mounted ? 'opacity-100' : 'opacity-0'` gate held
+             * content invisible until the client hydrated AND the
+             * 1000ms transition completed. Since this section is
+             * always visible at first paint, the gate added cost
+             * with no UX benefit. Removed entirely.
+             */}
+            <div className="space-y-8">
               {/* Eyebrow */}
-              <div
-                className={`inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 text-primary text-sm font-medium transition-all duration-700 delay-100 ${mounted ? 'opacity-100' : 'opacity-0'}`}
-              >
+              <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 text-primary text-sm font-medium">
                 <span className="w-2 h-2 rounded-full bg-secondary animate-pulse" />
                 Available for opportunities
               </div>
 
               {/* Main Headline */}
               <div className="space-y-4">
-                <h1
-                  className={`font-display text-5xl md:text-6xl lg:text-7xl font-bold text-foreground leading-[1.1] tracking-tight transition-all duration-700 delay-200 ${mounted ? 'opacity-100' : 'opacity-0'}`}
-                >
+                <h1 className="font-display text-5xl md:text-6xl lg:text-7xl font-bold text-foreground leading-[1.1] tracking-tight">
                   Transforming{' '}
                   <span className="relative">
                     <span className="relative z-10 text-primary">Revenue</span>
@@ -133,9 +125,7 @@ export default function HomePageContent() {
                   <br />
                   Operations
                 </h1>
-                <p
-                  className={`text-xl md:text-2xl text-muted-foreground max-w-lg leading-relaxed transition-all duration-700 delay-300 ${mounted ? 'opacity-100' : 'opacity-0'}`}
-                >
+                <p className="text-xl md:text-2xl text-muted-foreground max-w-lg leading-relaxed">
                   Data-driven strategies that deliver{' '}
                   <span className="text-accent font-semibold">measurable impact</span> and scalable
                   growth.
@@ -143,9 +133,7 @@ export default function HomePageContent() {
               </div>
 
               {/* CTA Buttons */}
-              <div
-                className={`flex flex-wrap gap-4 transition-all duration-700 delay-500 ${mounted ? 'opacity-100' : 'opacity-0'}`}
-              >
+              <div className="flex flex-wrap gap-4">
                 <Button asChild size="lg" className="group h-14 px-8 text-base font-semibold">
                   <Link href="/projects">
                     <Briefcase className="w-5 h-5" />
@@ -178,10 +166,8 @@ export default function HomePageContent() {
               </div>
             </div>
 
-            {/* Right Column - Profile Card */}
-            <div
-              className={`relative transition-all duration-1000 delay-300 ${mounted ? 'opacity-100 translate-y-0 scale-100' : 'opacity-0 translate-y-8 scale-95'}`}
-            >
+            {/* Right Column - Profile Card (above-the-fold; no mount-gate, see hero comment above) */}
+            <div className="relative">
               {/* Card with depth */}
               <div className="relative">
                 {/* Shadow layer */}

--- a/src/components/projects/project-page-layout.tsx
+++ b/src/components/projects/project-page-layout.tsx
@@ -37,7 +37,12 @@ export const ProjectPageLayout = React.forwardRef<HTMLDivElement, ProjectPageLay
     return (
       <div
         ref={ref}
-        className={cn('min-h-screen bg-background overflow-hidden', className)}
+        // `relative` establishes the positioning context so the decorative
+        // -right-32/-left-32 blurs below are clipped by `overflow-hidden`.
+        // Without it, absolute children escape to body coordinates and
+        // produce horizontal page scroll on every project detail route
+        // (browser audit 2026-05-10: scrollWidth>innerWidth at <=1024px).
+        className={cn('relative min-h-screen bg-background overflow-hidden', className)}
         {...props}
       >
         {/* Decorative background elements */}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -55,9 +55,22 @@ function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
   )
 }
 
-function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+// Polymorphic via `as` so consumers can render CardTitle as the correct
+// semantic heading for the document outline (h2/h3/etc.) without forking
+// the styling. Defaults to <div> for backwards compatibility with existing
+// consumers that don't need a heading (e.g. dashboards, status panels).
+type CardTitleProps<T extends React.ElementType = 'div'> = {
+  as?: T
+} & Omit<React.ComponentPropsWithoutRef<T>, 'as'>
+
+function CardTitle<T extends React.ElementType = 'div'>({
+  as,
+  className,
+  ...props
+}: CardTitleProps<T>) {
+  const Component = (as ?? 'div') as React.ElementType
   return (
-    <div
+    <Component
       data-slot="card-title"
       className={cn('leading-none font-semibold', className)}
       {...props}

--- a/src/components/ui/section-card.tsx
+++ b/src/components/ui/section-card.tsx
@@ -84,7 +84,14 @@ const SectionCard = React.forwardRef<HTMLDivElement, SectionCardProps>(
         {...props}
       >
         <div className={cn(sectionCardHeaderVariants({ padding }))}>
-          <h3 className={cn(sectionCardTitleVariants({ padding }))}>{title}</h3>
+          {/*
+           * h2: SectionCard renders a top-level page section under the page <h1>.
+           * Browser audit found 12/14 project pages skipped H1 → H3 with no H2,
+           * triggering screen-reader outline gaps. Promoting to h2 here fixes
+           * every consumer at once. Children that nest below SectionCard should
+           * use h3+ for their internal headings.
+           */}
+          <h2 className={cn(sectionCardTitleVariants({ padding }))}>{title}</h2>
           {description && (
             <p className={cn(sectionCardDescriptionVariants({ padding }))}>{description}</p>
           )}

--- a/src/components/ui/section-card.tsx
+++ b/src/components/ui/section-card.tsx
@@ -67,16 +67,28 @@ const sectionCardDescriptionVariants = cva('text-muted-foreground leading-relaxe
   },
 })
 
+type HeadingLevel = 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+
 interface SectionCardProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof sectionCardVariants> {
   title: string
   description?: string
   children: React.ReactNode
+  /**
+   * Semantic heading element for the title. Defaults to `h2` because
+   * SectionCard is the canonical wrapper for top-level page sections
+   * directly under the page `<h1>`. Override when nesting (e.g. a
+   * SectionCard inside another SectionCard should pass `as="h3"`).
+   */
+  as?: HeadingLevel
 }
 
 const SectionCard = React.forwardRef<HTMLDivElement, SectionCardProps>(
-  ({ className, variant, padding, title, description, children, ...props }, ref) => {
+  (
+    { className, variant, padding, title, description, children, as: Heading = 'h2', ...props },
+    ref
+  ) => {
     return (
       <div
         ref={ref}
@@ -84,14 +96,7 @@ const SectionCard = React.forwardRef<HTMLDivElement, SectionCardProps>(
         {...props}
       >
         <div className={cn(sectionCardHeaderVariants({ padding }))}>
-          {/*
-           * h2: SectionCard renders a top-level page section under the page <h1>.
-           * Browser audit found 12/14 project pages skipped H1 → H3 with no H2,
-           * triggering screen-reader outline gaps. Promoting to h2 here fixes
-           * every consumer at once. Children that nest below SectionCard should
-           * use h3+ for their internal headings.
-           */}
-          <h2 className={cn(sectionCardTitleVariants({ padding }))}>{title}</h2>
+          <Heading className={cn(sectionCardTitleVariants({ padding }))}>{title}</Heading>
           {description && (
             <p className={cn(sectionCardDescriptionVariants({ padding }))}>{description}</p>
           )}


### PR DESCRIPTION
## Summary

Browser audit of richardwhudsonjr.com surfaced 9 findings (1 Critical, 3 High, 4 Medium, 1 Low). This PR closes 8 — 7 with new code commits and 1 verified to already be fixed on main. The 9th (duplicate cover image) is a content/data issue with no code change applicable.

| # | Severity | Finding | Status | Commit |
|---|---|---|---|---|
| 1 | CRITICAL | 3 not-found routes returned HTTP 200 (soft 404) | Verified already fixed on main (commit \`6d1ee82\` added \`force-dynamic\` to all 3 slug routes); audit hit stale CDN | — |
| 2 | HIGH | Tab clicks didn't update \`?tab=\` URL on 6 project pages | FIXED — root cause: client components had invalid \`export const dynamic = 'force-static'\` which suppressed nuqs URL writes | \`024b5d6\` |
| 3 | HIGH | Horizontal overflow on 14/14 project pages at viewport ≤1024px | FIXED — \`overflow-x: hidden\` on html/body | \`3cfc360\` |
| 4 | HIGH | Duplicate \`<h1>\` on a blog post | FIXED — defensive demote of in-body \`<h1>\` to \`<h2>\` for HTML/RICH_TEXT posts. **Content-side cleanup still recommended:** the markdown body of the affected post should also be edited in the DB to remove its leading \`# Title\` | \`d8308a2\` |
| 5 | MEDIUM | Blog cards missing heading semantics (only h1 in tree on /blog and /blog/category) | FIXED — post card titles wrapped in \`<h2>\` | \`0fbc40c\` |
| 6 | MEDIUM | Skipped heading levels (h1→h3) on 12/14 project pages | FIXED — SectionCard title promoted h3 → h2 so document outline goes h1 (page) → h2 (section) → h3 (subsection) | \`d700ac4\` |
| 7 | MEDIUM | Hero/counter opacity-0 flash for 2-6s on initial paint (homepage, /resume, /projects/revenue-kpi) | FIXED — removed mount/in-view opacity gates from above-the-fold heroes; counters render immediately at startValue=0 and animate up | \`0c0b8be\` |
| 8 | MEDIUM | Duplicate cover image across 2 blog post cards | SKIPPED — content/data issue (no code change applicable) | — |
| 9 | LOW | Generic site title on \`/nonexistent\` 404 | FIXED — added \`metadata\` export to root not-found.tsx with title "404 — Page Not Found" + noindex | \`43de7eb\` |

## Verification

- [x] \`bunx vitest run\` — 997/997 pass
- [x] \`bun run typecheck\` — clean
- [x] \`bun run lint\` — clean

## Re-audit recommended after Vercel deploys

Confirm the following on production after this lands:
- \`/blog/<bad>\`, \`/projects/<bad>\`, \`/blog/category/<bad>\` return HTTP 404 (verify via \`curl -sI\`)
- Tab clicks on \`/projects/cac-unit-economics\` push \`?tab=channels\` to URL
- No horizontal scroll at 982px viewport on any project page
- Hero copy is visible immediately on /, /resume, /projects/revenue-kpi (no 2-6s opacity flash)

[hudsor01]