### PR TITLE
fix(api): require admin token on blog write endpoints

### DIFF
--- a/src/app/api/blog/[slug]/__tests__/route.test.ts
+++ b/src/app/api/blog/[slug]/__tests__/route.test.ts
@@ -8,6 +8,10 @@ vi.mock('@/lib/api-csrf', () => ({
 vi.mock('@/lib/api-admin-auth', () => ({
   isAdminRequest: vi.fn(() => false),
 }))
+vi.mock('@/lib/api-rate-limit', () => ({
+  checkRateLimitOrRespond: vi.fn(() => null),
+  RateLimitPresets: { read: {}, write: {}, sensitive: {} },
+}))
 
 const dbMocks = vi.hoisted(() => ({
   findFirst: vi.fn(),

--- a/src/app/api/blog/[slug]/__tests__/route.test.ts
+++ b/src/app/api/blog/[slug]/__tests__/route.test.ts
@@ -167,7 +167,16 @@ describe('GET /api/blog/[slug]', () => {
 describe('PUT /api/blog/[slug]', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(isAdminRequest).mockReturnValue(true)
     vi.mocked(validateCSRFOrRespond).mockResolvedValue(null)
+  })
+
+  it('returns 401 when admin token missing', async () => {
+    vi.mocked(isAdminRequest).mockReturnValueOnce(false)
+    const res = await PUT(reqPut('hello', { title: 'New' }), ctx('hello'))
+    expect(res.status).toBe(401)
+    expect(vi.mocked(validateCSRFOrRespond)).not.toHaveBeenCalled()
+    expect(dbMocks.findFirst).not.toHaveBeenCalled()
   })
 
   it('returns 403 when CSRF guard responds (CSRF required for mutation)', async () => {
@@ -201,7 +210,16 @@ describe('PUT /api/blog/[slug]', () => {
 describe('DELETE /api/blog/[slug]', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(isAdminRequest).mockReturnValue(true)
     vi.mocked(validateCSRFOrRespond).mockResolvedValue(null)
+  })
+
+  it('returns 401 when admin token missing', async () => {
+    vi.mocked(isAdminRequest).mockReturnValueOnce(false)
+    const res = await DELETE(reqDelete('hello'), ctx('hello'))
+    expect(res.status).toBe(401)
+    expect(vi.mocked(validateCSRFOrRespond)).not.toHaveBeenCalled()
+    expect(dbMocks.findFirst).not.toHaveBeenCalled()
   })
 
   it('returns 403 when CSRF guard responds', async () => {

--- a/src/app/api/blog/[slug]/route.ts
+++ b/src/app/api/blog/[slug]/route.ts
@@ -81,6 +81,7 @@ export async function GET(request: NextRequest, context: { params: Promise<{ slu
 
 export async function PUT(request: NextRequest, context: { params: Promise<{ slug: string }> }) {
   if (!isAdminRequest(request)) {
+    logger.warn('Unauthorized blog mutation attempt', { route: '/api/blog/[slug]', method: 'PUT' })
     return NextResponse.json(createErrorResponse('Unauthorized'), { status: 401 })
   }
 
@@ -215,6 +216,10 @@ export async function PUT(request: NextRequest, context: { params: Promise<{ slu
 
 export async function DELETE(request: NextRequest, context: { params: Promise<{ slug: string }> }) {
   if (!isAdminRequest(request)) {
+    logger.warn('Unauthorized blog mutation attempt', {
+      route: '/api/blog/[slug]',
+      method: 'DELETE',
+    })
     return NextResponse.json(createErrorResponse('Unauthorized'), { status: 401 })
   }
 

--- a/src/app/api/blog/[slug]/route.ts
+++ b/src/app/api/blog/[slug]/route.ts
@@ -80,6 +80,10 @@ export async function GET(request: NextRequest, context: { params: Promise<{ slu
 }
 
 export async function PUT(request: NextRequest, context: { params: Promise<{ slug: string }> }) {
+  if (!isAdminRequest(request)) {
+    return NextResponse.json(createErrorResponse('Unauthorized'), { status: 401 })
+  }
+
   const csrfResponse = await validateCSRFOrRespond(request, 'blog post update')
   if (csrfResponse) return csrfResponse
 
@@ -210,6 +214,10 @@ export async function PUT(request: NextRequest, context: { params: Promise<{ slu
 }
 
 export async function DELETE(request: NextRequest, context: { params: Promise<{ slug: string }> }) {
+  if (!isAdminRequest(request)) {
+    return NextResponse.json(createErrorResponse('Unauthorized'), { status: 401 })
+  }
+
   const csrfResponse = await validateCSRFOrRespond(request, 'blog post deletion')
   if (csrfResponse) return csrfResponse
 

--- a/src/app/api/blog/[slug]/route.ts
+++ b/src/app/api/blog/[slug]/route.ts
@@ -6,6 +6,7 @@ import { db } from '@/lib/db'
 import { authors, blogPosts, categories, postTags, tags, type NewBlogPost } from '@/db/schema'
 import { validateCSRFOrRespond } from '@/lib/api-csrf'
 import { isAdminRequest } from '@/lib/api-admin-auth'
+import { checkRateLimitOrRespond, RateLimitPresets } from '@/lib/api-rate-limit'
 import { transformToBlogPostData, createErrorResponse } from '@/lib/api-blog'
 import { updateBlogPostSchema } from '@/lib/schemas'
 
@@ -80,6 +81,14 @@ export async function GET(request: NextRequest, context: { params: Promise<{ slu
 }
 
 export async function PUT(request: NextRequest, context: { params: Promise<{ slug: string }> }) {
+  const rateLimitResponse = checkRateLimitOrRespond(
+    request,
+    RateLimitPresets.sensitive,
+    '/api/blog/[slug]',
+    'PUT'
+  )
+  if (rateLimitResponse) return rateLimitResponse
+
   if (!isAdminRequest(request)) {
     logger.warn('Unauthorized blog mutation attempt', { route: '/api/blog/[slug]', method: 'PUT' })
     return NextResponse.json(createErrorResponse('Unauthorized'), { status: 401 })
@@ -215,6 +224,14 @@ export async function PUT(request: NextRequest, context: { params: Promise<{ slu
 }
 
 export async function DELETE(request: NextRequest, context: { params: Promise<{ slug: string }> }) {
+  const rateLimitResponse = checkRateLimitOrRespond(
+    request,
+    RateLimitPresets.sensitive,
+    '/api/blog/[slug]',
+    'DELETE'
+  )
+  if (rateLimitResponse) return rateLimitResponse
+
   if (!isAdminRequest(request)) {
     logger.warn('Unauthorized blog mutation attempt', {
       route: '/api/blog/[slug]',

--- a/src/app/api/blog/__tests__/route.test.ts
+++ b/src/app/api/blog/__tests__/route.test.ts
@@ -71,6 +71,7 @@ vi.mock('@/lib/logger', () => ({
 import { GET, POST } from '@/app/api/blog/route'
 import { validateCSRFOrRespond } from '@/lib/api-csrf'
 import { checkRateLimitOrRespond } from '@/lib/api-rate-limit'
+import { isAdminRequest } from '@/lib/api-admin-auth'
 
 const sampleAuthorId = 'cl1234567890abcdefghijkl'
 const sampleCategoryId = 'cl9876543210abcdefghijkl'
@@ -190,6 +191,7 @@ describe('POST /api/blog', () => {
     vi.clearAllMocks()
     vi.mocked(checkRateLimitOrRespond).mockReturnValue(null)
     vi.mocked(validateCSRFOrRespond).mockResolvedValue(null)
+    vi.mocked(isAdminRequest).mockReturnValue(true)
     // findFirst by slug → no existing post; then second findFirst for read-back returns the new post.
     dbMocks.findFirst.mockResolvedValueOnce(undefined).mockResolvedValueOnce(samplePost)
     dbMocks.insertReturning.mockResolvedValue([{ id: samplePost.id }])
@@ -203,6 +205,14 @@ describe('POST /api/blog', () => {
     authorId: sampleAuthorId,
     status: 'DRAFT' as const,
   }
+
+  it('returns 401 when admin token missing', async () => {
+    vi.mocked(isAdminRequest).mockReturnValueOnce(false)
+    const res = await POST(reqPost(validBody))
+    expect(res.status).toBe(401)
+    expect(vi.mocked(validateCSRFOrRespond)).not.toHaveBeenCalled()
+    expect(dbMocks.findFirst).not.toHaveBeenCalled()
+  })
 
   it('returns 403 when CSRF guard responds', async () => {
     vi.mocked(validateCSRFOrRespond).mockResolvedValueOnce(

--- a/src/app/api/blog/categories/__tests__/route.test.ts
+++ b/src/app/api/blog/categories/__tests__/route.test.ts
@@ -5,6 +5,9 @@ import { NextRequest, NextResponse } from 'next/server'
 vi.mock('@/lib/api-csrf', () => ({
   validateCSRFOrRespond: vi.fn(async () => null),
 }))
+vi.mock('@/lib/api-admin-auth', () => ({
+  isAdminRequest: vi.fn(() => true),
+}))
 
 const dbMocks = vi.hoisted(() => ({
   selectRows: vi.fn(),
@@ -44,6 +47,7 @@ vi.mock('@/lib/logger', () => ({
 
 import { GET, POST } from '@/app/api/blog/categories/route'
 import { validateCSRFOrRespond } from '@/lib/api-csrf'
+import { isAdminRequest } from '@/lib/api-admin-auth'
 
 const sampleCategory = {
   id: 'cat-1',
@@ -96,9 +100,18 @@ describe('GET /api/blog/categories', () => {
 describe('POST /api/blog/categories', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(isAdminRequest).mockReturnValue(true)
     vi.mocked(validateCSRFOrRespond).mockResolvedValue(null)
     dbMocks.findFirst.mockResolvedValue(undefined)
     dbMocks.insertReturning.mockResolvedValue([sampleCategory])
+  })
+
+  it('returns 401 when admin token missing', async () => {
+    vi.mocked(isAdminRequest).mockReturnValueOnce(false)
+    const res = await POST(reqPost({ name: 'Revenue Operations' }))
+    expect(res.status).toBe(401)
+    expect(vi.mocked(validateCSRFOrRespond)).not.toHaveBeenCalled()
+    expect(dbMocks.findFirst).not.toHaveBeenCalled()
   })
 
   it('returns 403 when CSRF guard responds', async () => {

--- a/src/app/api/blog/categories/__tests__/route.test.ts
+++ b/src/app/api/blog/categories/__tests__/route.test.ts
@@ -8,6 +8,10 @@ vi.mock('@/lib/api-csrf', () => ({
 vi.mock('@/lib/api-admin-auth', () => ({
   isAdminRequest: vi.fn(() => true),
 }))
+vi.mock('@/lib/api-rate-limit', () => ({
+  checkRateLimitOrRespond: vi.fn(() => null),
+  RateLimitPresets: { read: {}, write: {}, sensitive: {} },
+}))
 
 const dbMocks = vi.hoisted(() => ({
   selectRows: vi.fn(),

--- a/src/app/api/blog/categories/route.ts
+++ b/src/app/api/blog/categories/route.ts
@@ -41,6 +41,10 @@ export async function GET() {
 export async function POST(request: NextRequest) {
   try {
     if (!isAdminRequest(request)) {
+      logger.warn('Unauthorized blog mutation attempt', {
+        route: '/api/blog/categories',
+        method: 'POST',
+      })
       return NextResponse.json(createErrorResponse('Unauthorized'), { status: 401 })
     }
 

--- a/src/app/api/blog/categories/route.ts
+++ b/src/app/api/blog/categories/route.ts
@@ -7,6 +7,7 @@ import { createContextLogger } from '@/lib/logger'
 import { generateSlug, createErrorResponse, transformToCategoryData } from '@/lib/api-blog'
 import { validateCSRFOrRespond } from '@/lib/api-csrf'
 import { isAdminRequest } from '@/lib/api-admin-auth'
+import { checkRateLimitOrRespond, RateLimitPresets } from '@/lib/api-rate-limit'
 
 const logger = createContextLogger('CategoriesAPI')
 
@@ -39,6 +40,14 @@ export async function GET() {
 }
 
 export async function POST(request: NextRequest) {
+  const rateLimitResponse = checkRateLimitOrRespond(
+    request,
+    RateLimitPresets.sensitive,
+    '/api/blog/categories',
+    'POST'
+  )
+  if (rateLimitResponse) return rateLimitResponse
+
   try {
     if (!isAdminRequest(request)) {
       logger.warn('Unauthorized blog mutation attempt', {

--- a/src/app/api/blog/categories/route.ts
+++ b/src/app/api/blog/categories/route.ts
@@ -6,6 +6,7 @@ import { categories } from '@/db/schema'
 import { createContextLogger } from '@/lib/logger'
 import { generateSlug, createErrorResponse, transformToCategoryData } from '@/lib/api-blog'
 import { validateCSRFOrRespond } from '@/lib/api-csrf'
+import { isAdminRequest } from '@/lib/api-admin-auth'
 
 const logger = createContextLogger('CategoriesAPI')
 
@@ -39,6 +40,10 @@ export async function GET() {
 
 export async function POST(request: NextRequest) {
   try {
+    if (!isAdminRequest(request)) {
+      return NextResponse.json(createErrorResponse('Unauthorized'), { status: 401 })
+    }
+
     const csrfResponse = await validateCSRFOrRespond(request, 'blog category creation')
     if (csrfResponse) return csrfResponse
 

--- a/src/app/api/blog/route.ts
+++ b/src/app/api/blog/route.ts
@@ -157,6 +157,10 @@ export async function POST(request: NextRequest) {
   )
   if (rateLimitResponse) return rateLimitResponse
 
+  if (!isAdminRequest(request)) {
+    return NextResponse.json(createErrorResponse('Unauthorized'), { status: 401 })
+  }
+
   // CSRF validation using shared utility
   const csrfResponse = await validateCSRFOrRespond(request, 'blog post creation')
   if (csrfResponse) return csrfResponse

--- a/src/app/api/blog/route.ts
+++ b/src/app/api/blog/route.ts
@@ -158,6 +158,7 @@ export async function POST(request: NextRequest) {
   if (rateLimitResponse) return rateLimitResponse
 
   if (!isAdminRequest(request)) {
+    logger.warn('Unauthorized blog mutation attempt', { route: '/api/blog', method: 'POST' })
     return NextResponse.json(createErrorResponse('Unauthorized'), { status: 401 })
   }
 

--- a/src/app/api/blog/tags/__tests__/route.test.ts
+++ b/src/app/api/blog/tags/__tests__/route.test.ts
@@ -5,6 +5,9 @@ import { NextRequest, NextResponse } from 'next/server'
 vi.mock('@/lib/api-csrf', () => ({
   validateCSRFOrRespond: vi.fn(async () => null),
 }))
+vi.mock('@/lib/api-admin-auth', () => ({
+  isAdminRequest: vi.fn(() => true),
+}))
 
 const dbMocks = vi.hoisted(() => ({
   selectRows: vi.fn(),
@@ -49,6 +52,7 @@ vi.mock('@/lib/logger', () => ({
 
 import { GET, POST } from '@/app/api/blog/tags/route'
 import { validateCSRFOrRespond } from '@/lib/api-csrf'
+import { isAdminRequest } from '@/lib/api-admin-auth'
 
 const sampleTag = {
   id: 'tag-1',
@@ -104,9 +108,18 @@ describe('GET /api/blog/tags', () => {
 describe('POST /api/blog/tags', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(isAdminRequest).mockReturnValue(true)
     vi.mocked(validateCSRFOrRespond).mockResolvedValue(null)
     dbMocks.findFirst.mockResolvedValue(undefined)
     dbMocks.insertReturning.mockResolvedValue([sampleTag])
+  })
+
+  it('returns 401 when admin token missing', async () => {
+    vi.mocked(isAdminRequest).mockReturnValueOnce(false)
+    const res = await POST(reqPost({ name: 'rev-ops' }))
+    expect(res.status).toBe(401)
+    expect(vi.mocked(validateCSRFOrRespond)).not.toHaveBeenCalled()
+    expect(dbMocks.findFirst).not.toHaveBeenCalled()
   })
 
   it('returns 403 when CSRF guard responds', async () => {

--- a/src/app/api/blog/tags/__tests__/route.test.ts
+++ b/src/app/api/blog/tags/__tests__/route.test.ts
@@ -8,6 +8,10 @@ vi.mock('@/lib/api-csrf', () => ({
 vi.mock('@/lib/api-admin-auth', () => ({
   isAdminRequest: vi.fn(() => true),
 }))
+vi.mock('@/lib/api-rate-limit', () => ({
+  checkRateLimitOrRespond: vi.fn(() => null),
+  RateLimitPresets: { read: {}, write: {}, sensitive: {} },
+}))
 
 const dbMocks = vi.hoisted(() => ({
   selectRows: vi.fn(),

--- a/src/app/api/blog/tags/route.ts
+++ b/src/app/api/blog/tags/route.ts
@@ -52,6 +52,10 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     if (!isAdminRequest(request)) {
+      logger.warn('Unauthorized blog mutation attempt', {
+        route: '/api/blog/tags',
+        method: 'POST',
+      })
       return NextResponse.json(createErrorResponse('Unauthorized'), { status: 401 })
     }
 

--- a/src/app/api/blog/tags/route.ts
+++ b/src/app/api/blog/tags/route.ts
@@ -7,6 +7,7 @@ import { tags } from '@/db/schema'
 import { generateSlug, createErrorResponse, transformToTagData } from '@/lib/api-blog'
 import { validateCSRFOrRespond } from '@/lib/api-csrf'
 import { isAdminRequest } from '@/lib/api-admin-auth'
+import { checkRateLimitOrRespond, RateLimitPresets } from '@/lib/api-rate-limit'
 
 const logger = createContextLogger('TagsAPI')
 
@@ -50,6 +51,14 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  const rateLimitResponse = checkRateLimitOrRespond(
+    request,
+    RateLimitPresets.sensitive,
+    '/api/blog/tags',
+    'POST'
+  )
+  if (rateLimitResponse) return rateLimitResponse
+
   try {
     if (!isAdminRequest(request)) {
       logger.warn('Unauthorized blog mutation attempt', {

--- a/src/app/api/blog/tags/route.ts
+++ b/src/app/api/blog/tags/route.ts
@@ -6,6 +6,7 @@ import { db } from '@/lib/db'
 import { tags } from '@/db/schema'
 import { generateSlug, createErrorResponse, transformToTagData } from '@/lib/api-blog'
 import { validateCSRFOrRespond } from '@/lib/api-csrf'
+import { isAdminRequest } from '@/lib/api-admin-auth'
 
 const logger = createContextLogger('TagsAPI')
 
@@ -50,6 +51,10 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
+    if (!isAdminRequest(request)) {
+      return NextResponse.json(createErrorResponse('Unauthorized'), { status: 401 })
+    }
+
     const csrfResponse = await validateCSRFOrRespond(request, 'blog tag creation')
     if (csrfResponse) return csrfResponse
 

--- a/src/app/api/seed/route.ts
+++ b/src/app/api/seed/route.ts
@@ -12,7 +12,7 @@ export async function POST(request: NextRequest) {
   }
 
   if (!isAdminRequest(request)) {
-    logger.warn('Unauthorized seed attempt', { route: 'api/seed' })
+    logger.warn('Unauthorized seed attempt', { route: '/api/seed' })
     return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -26,7 +26,7 @@ export async function POST(request: NextRequest) {
       })
     }
 
-    logger.info('Seeding database via API', { route: 'api/seed' })
+    logger.info('Seeding database via API', { route: '/api/seed' })
 
     const authorRows = await db
       .insert(authors)
@@ -150,7 +150,7 @@ In the age of big data, making decisions based on intuition alone is no longer s
     })
   } catch (error) {
     logger.error('Seeding failed', error instanceof Error ? error : new Error(String(error)), {
-      route: 'api/seed',
+      route: '/api/seed',
     })
     return NextResponse.json(
       {

--- a/src/lib/env-validation.ts
+++ b/src/lib/env-validation.ts
@@ -119,7 +119,11 @@ export function performSecurityChecks(env: EnvConfig): void {
       warnings.push('Production JWT_SECRET should be at least 64 characters')
     }
 
-    if (env.ADMIN_API_TOKEN && env.ADMIN_API_TOKEN.length < 64) {
+    if (!env.ADMIN_API_TOKEN) {
+      warnings.push(
+        'ADMIN_API_TOKEN unset in production — /api/seed and all blog mutation endpoints (POST/PUT/DELETE) will return 401 to every caller, including legitimate admins'
+      )
+    } else if (env.ADMIN_API_TOKEN.length < 64) {
       warnings.push('Production ADMIN_API_TOKEN should be at least 64 characters')
     }
 


### PR DESCRIPTION
## Summary

- Blog mutation endpoints were gated only on CSRF double-submit, which doesn't authenticate non-browser callers — both the `__csrf_token` cookie and `x-csrf-token` header are attacker-controlled in a scripted request. Anyone could `DELETE` published posts or `POST` arbitrary content via curl.
- Added `isAdminRequest` gate ahead of the CSRF check in `POST /api/blog`, `PUT /api/blog/[slug]`, `DELETE /api/blog/[slug]`, `POST /api/blog/tags`, `POST /api/blog/categories`, mirroring the existing pattern in `/api/seed`. CSRF stays as defense-in-depth.
- `CLAUDE.md` already documents the model as *"token-gated admin endpoints + CSRF on mutations"*; the admin-token half was missing on every write path that needed it.

## Proof of bug (pre-fix)

```bash
TOKEN=$(openssl rand -hex 32)
curl -X DELETE https://richardwhudsonjr.com/api/blog/<slug> \
  -H "x-csrf-token: $TOKEN" \
  -H "cookie: __csrf_token=$TOKEN"
```

## Test plan

- [x] `bunx vitest run` — 1015/1015 pass; new 401 assertions cover the missing-token path on all five handlers
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] Existing CSRF/rate-limit/happy-path tests still pass with `isAdminRequest` mocked to `true` in `beforeEach`
- [ ] Smoke test in prod after deploy: `curl -X DELETE` without `Authorization: Bearer` returns 401; with valid `ADMIN_API_TOKEN` returns 200

[hudsor01]