### PR TITLE
fix(security): guard CSRF length mismatch to prevent 500s on malformed tokens

### DIFF
--- a/e2e/security-headers.spec.ts
+++ b/e2e/security-headers.spec.ts
@@ -160,6 +160,24 @@ test.describe('Security Headers', () => {
       expect(body.error).toBeDefined()
     })
 
+    // Regression pin for the RangeError-on-length-mismatch bug fixed in
+    // PR #101: a malformed (wrong-length) CSRF token must return 403, not 500.
+    // Pre-fix, crypto.timingSafeEqual threw on the unequal Buffers and the
+    // throw escaped the route handler. /api/contact is CSRF-protected and
+    // (unlike /api/blog/*) doesn't require admin bearer auth, so the CSRF
+    // check is reachable end-to-end without additional setup.
+    test('POST with malformed-length CSRF token returns 403, not 500', async ({ request }) => {
+      const response = await request.post('/api/contact', {
+        data: { name: 'Test', email: 'test@example.com', message: 'Hello' },
+        headers: {
+          'Content-Type': 'application/json',
+          'x-csrf-token': 'short',
+          Cookie: `__csrf_token=${'a'.repeat(64)}`,
+        },
+      })
+      expect(response.status()).toBe(403)
+    })
+
   })
 
   test.describe('API Route Headers', () => {

--- a/src/app/api/security/metrics/route.ts
+++ b/src/app/api/security/metrics/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server'
-import crypto from 'node:crypto'
 import { getRateLimiter } from '@/lib/rate-limiter/store'
 import { env } from '@/lib/env-validation'
+import { timingSafeEqualString } from '@/lib/timing-safe-equal'
 
 export async function GET(request: NextRequest) {
   // If METRICS_API_TOKEN is not configured, endpoint is disabled
@@ -11,19 +11,7 @@ export async function GET(request: NextRequest) {
 
   const token = request.headers.get('X-Metrics-Token')
 
-  if (!token) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
-  }
-
-  // Constant-time comparison to prevent timing attacks
-  // timingSafeEqual throws if lengths differ, so check first
-  const tokenBuffer = Buffer.from(token)
-  const expectedBuffer = Buffer.from(env.METRICS_API_TOKEN)
-
-  if (
-    tokenBuffer.length !== expectedBuffer.length ||
-    !crypto.timingSafeEqual(tokenBuffer, expectedBuffer)
-  ) {
+  if (!token || !timingSafeEqualString(token, env.METRICS_API_TOKEN)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
   }
 

--- a/src/lib/__tests__/csrf-protection.test.ts
+++ b/src/lib/__tests__/csrf-protection.test.ts
@@ -78,6 +78,29 @@ describe('validateCSRFToken', () => {
     const result = await validateCSRFToken('')
     expect(result).toBe(false)
   })
+
+  it('returns false (no throw) when requestToken is shorter than stored token', async () => {
+    mockCookieStore.get.mockReturnValue({ value: generateCSRFToken() })
+    await expect(validateCSRFToken('short')).resolves.toBe(false)
+  })
+
+  it('returns false (no throw) when requestToken is longer than stored token', async () => {
+    mockCookieStore.get.mockReturnValue({ value: generateCSRFToken() })
+    await expect(validateCSRFToken('a'.repeat(128))).resolves.toBe(false)
+  })
+
+  it('returns false (no throw) when requestToken differs by one byte in length', async () => {
+    mockCookieStore.get.mockReturnValue({ value: generateCSRFToken() })
+    await expect(validateCSRFToken('a'.repeat(63))).resolves.toBe(false)
+    await expect(validateCSRFToken('a'.repeat(65))).resolves.toBe(false)
+  })
+
+  it('returns false (no throw) for multi-byte UTF-8 chars that change byte length vs char length', async () => {
+    // 'é' is 2 bytes in UTF-8; 32 'é' chars = 64 chars but 128 bytes.
+    // Buffer comparison must use byte length, not char length.
+    mockCookieStore.get.mockReturnValue({ value: generateCSRFToken() })
+    await expect(validateCSRFToken('é'.repeat(32))).resolves.toBe(false)
+  })
 })
 
 describe('createNewCSRFToken', () => {

--- a/src/lib/__tests__/timing-safe-equal.test.ts
+++ b/src/lib/__tests__/timing-safe-equal.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest'
+import { timingSafeEqualString } from '@/lib/timing-safe-equal'
+
+describe('timingSafeEqualString', () => {
+  it('returns true for identical strings', () => {
+    expect(timingSafeEqualString('a'.repeat(64), 'a'.repeat(64))).toBe(true)
+  })
+
+  it('returns false for same-length, different-content strings', () => {
+    expect(timingSafeEqualString('a'.repeat(64), 'b'.repeat(64))).toBe(false)
+  })
+
+  it('returns false (no throw) for shorter input', () => {
+    expect(timingSafeEqualString('short', 'a'.repeat(64))).toBe(false)
+  })
+
+  it('returns false (no throw) for longer input', () => {
+    expect(timingSafeEqualString('a'.repeat(128), 'a'.repeat(64))).toBe(false)
+  })
+
+  it('returns false (no throw) for off-by-one length', () => {
+    expect(timingSafeEqualString('a'.repeat(63), 'a'.repeat(64))).toBe(false)
+    expect(timingSafeEqualString('a'.repeat(65), 'a'.repeat(64))).toBe(false)
+  })
+
+  it('compares by byte length, not char length (multi-byte UTF-8)', () => {
+    // 'é' is 2 bytes; 32 chars = 64 chars but 128 bytes — must not match 64-byte ASCII.
+    expect(timingSafeEqualString('é'.repeat(32), 'a'.repeat(64))).toBe(false)
+  })
+
+  it('returns true for empty strings (both)', () => {
+    expect(timingSafeEqualString('', '')).toBe(true)
+  })
+
+  it('returns false when one side is empty', () => {
+    expect(timingSafeEqualString('', 'a'.repeat(64))).toBe(false)
+    expect(timingSafeEqualString('a'.repeat(64), '')).toBe(false)
+  })
+})

--- a/src/lib/api-admin-auth.ts
+++ b/src/lib/api-admin-auth.ts
@@ -1,6 +1,6 @@
 import 'server-only'
-import { timingSafeEqual } from 'node:crypto'
 import { env } from '@/lib/env-validation'
+import { timingSafeEqualString } from '@/lib/timing-safe-equal'
 
 /**
  * Constant-time check for the admin bearer token.
@@ -26,8 +26,5 @@ export function isAdminRequest(request: Request): boolean {
   if (!match) return false
 
   const provided = (match[1] ?? '').trim()
-  const a = Buffer.from(provided)
-  const b = Buffer.from(expected)
-  if (a.length !== b.length) return false
-  return timingSafeEqual(a, b)
+  return timingSafeEqualString(provided, expected)
 }

--- a/src/lib/api-csrf.ts
+++ b/src/lib/api-csrf.ts
@@ -21,7 +21,20 @@ export async function validateCSRFOrRespond(
   logContext?: string
 ): Promise<NextResponse | null> {
   const csrfToken = request.headers.get('x-csrf-token')
-  const isValid = await validateCSRFToken(csrfToken ?? undefined)
+
+  // Belt-and-suspenders: any throw inside validateCSRFToken (e.g. cookies()
+  // failing in a static-render context, or a future regression in the token
+  // comparison) collapses to a clean 403 rather than escaping to a 500 across
+  // all five mutation route handlers.
+  let isValid = false
+  try {
+    isValid = await validateCSRFToken(csrfToken ?? undefined)
+  } catch (error) {
+    logger.warn(`CSRF validation threw${logContext ? `: ${logContext}` : ''}`, {
+      clientId: getClientIdentifier(request),
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
 
   if (!isValid) {
     if (logContext) {

--- a/src/lib/csrf-protection.ts
+++ b/src/lib/csrf-protection.ts
@@ -52,8 +52,16 @@ export async function validateCSRFToken(requestToken: string | undefined): Promi
     return false
   }
 
-  // Use constant-time comparison to prevent timing attacks
-  return crypto.timingSafeEqual(Buffer.from(requestToken), Buffer.from(storedToken))
+  const requestBuffer = Buffer.from(requestToken)
+  const storedBuffer = Buffer.from(storedToken)
+
+  // timingSafeEqual throws RangeError on length mismatch — guard before calling
+  // so a malformed header returns 403 (via the caller) instead of crashing to 500.
+  if (requestBuffer.length !== storedBuffer.length) {
+    return false
+  }
+
+  return crypto.timingSafeEqual(requestBuffer, storedBuffer)
 }
 
 /**

--- a/src/lib/csrf-protection.ts
+++ b/src/lib/csrf-protection.ts
@@ -1,6 +1,7 @@
 import { cookies } from 'next/headers'
 import crypto from 'node:crypto'
 import { createContextLogger } from '@/lib/logger'
+import { timingSafeEqualString } from '@/lib/timing-safe-equal'
 
 const logger = createContextLogger('CSRFProtection')
 
@@ -52,16 +53,7 @@ export async function validateCSRFToken(requestToken: string | undefined): Promi
     return false
   }
 
-  const requestBuffer = Buffer.from(requestToken)
-  const storedBuffer = Buffer.from(storedToken)
-
-  // timingSafeEqual throws RangeError on length mismatch — guard before calling
-  // so a malformed header returns 403 (via the caller) instead of crashing to 500.
-  if (requestBuffer.length !== storedBuffer.length) {
-    return false
-  }
-
-  return crypto.timingSafeEqual(requestBuffer, storedBuffer)
+  return timingSafeEqualString(requestToken, storedToken)
 }
 
 /**

--- a/src/lib/timing-safe-equal.ts
+++ b/src/lib/timing-safe-equal.ts
@@ -1,0 +1,19 @@
+import { timingSafeEqual } from 'node:crypto'
+
+/**
+ * Constant-time string equality that never throws.
+ *
+ * crypto.timingSafeEqual requires equal-length buffers and throws RangeError
+ * otherwise — guard the length first so callers can use this in security
+ * boolean comparisons without a defensive try/catch.
+ *
+ * Length is NOT treated as secret here: in this codebase all compared strings
+ * are server-generated fixed-length tokens (CSRF token, ADMIN_API_TOKEN,
+ * METRICS_API_TOKEN) whose lengths are configuration constants, not secrets.
+ */
+export function timingSafeEqualString(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, 'utf8')
+  const bBuf = Buffer.from(b, 'utf8')
+  if (aBuf.length !== bBuf.length) return false
+  return timingSafeEqual(aBuf, bBuf)
+}


### PR DESCRIPTION
## Summary

Fixes a CSRF length-mismatch crash that surfaced as HTTP 500 (not 403) on every blog/contact mutation route. Extracted the length-guard pattern into a shared helper and hardened the CSRF guard with defense-in-depth.

### Root cause

`validateCSRFToken` called `crypto.timingSafeEqual` without checking buffer lengths first. The function throws `RangeError` on length mismatch, so any request with an `x-csrf-token` header whose byte length differed from the stored token (64 hex chars) crashed the comparison.

The throw escaped `validateCSRFOrRespond` (no try/catch) and landed outside the route handler's try block in `src/app/api/blog/route.ts:166-167` and the other blog mutation routes — Next.js returned generic HTTP 500 instead of the intended 403. Wrong status blocked frontend auto-refetch of stale tokens; malformed-probe traffic generated `error`-level Sentry events instead of `warn` breadcrumbs.

### Repro (pre-fix)

```bash
curl -X POST http://localhost:3000/api/contact \
  -H "x-csrf-token: short" \
  -H "Cookie: __csrf_token=<any 64-hex value>" \
  -H "Content-Type: application/json" -d '{}'
# → HTTP 500 + Sentry error event
```

## Changes

### Round 1 — minimal fix
- `src/lib/csrf-protection.ts`: guard buffer length before `crypto.timingSafeEqual`; return `false` on mismatch.
- Unit tests covering short, long, off-by-one, and multi-byte UTF-8 inputs.

### Round 2 — review-driven hardening
- **Extract `timingSafeEqualString(a, b)` helper** (`src/lib/timing-safe-equal.ts`). The same length-guard-then-timingSafeEqual dance was duplicated in three places (`csrf-protection.ts`, `api-admin-auth.ts`, `api/security/metrics/route.ts`). Refactor all three to use the helper so a fourth contributor can't cargo-cult a variant without the guard.
- **Defense-in-depth try/catch in `validateCSRFOrRespond`** (`src/lib/api-csrf.ts`): any future throw inside `validateCSRFToken` (e.g. `cookies()` failing in a static-render context) now collapses to a clean 403 across all five mutation routes instead of escaping to a 500.
- **E2E regression pin** for the malformed-length-CSRF-token path against `/api/contact` (`e2e/security-headers.spec.ts`). Unit tests mock the cookie store; only an e2e exercises the actual route handler end-to-end and proves no 500 escapes.

## Pre-existing issues found (filed separately)

- #102 — e2e: `/api/blog/tags` and `/api/blog/categories` CSRF tests return 401 after PR #100's admin gate
- #103 — csrf: cookie rotated on every GET, invalidates in-flight submissions in other tabs
- #104 — csrf: form-data CSRF extraction parses entire body before checking — DoS amplification

## Test plan

- [x] Failing unit tests added before the fix; confirmed `RangeError` thrown on `main`
- [x] After fix: 1027/1027 unit tests pass (added 8 for the helper)
- [x] Adjacent suites green: `api-csrf`, `csrf-protection`, `metrics-endpoint`, `api-admin-auth`, contact route, contact `csrf-route`
- [x] New e2e regression test passes: `POST with malformed-length CSRF token returns 403, not 500`
- [x] `bun run lint` clean (Biome)
- [x] `bun run typecheck` clean
- [x] Pre-commit + pre-push hooks ran cleanly

[hudsor01]