### PR TITLE
fix(rate-limiter): single-pass cleanup + full canonical hardening

### DIFF
--- a/src/lib/__tests__/rate-limiter.test.ts
+++ b/src/lib/__tests__/rate-limiter.test.ts
@@ -81,6 +81,46 @@ describe('RateLimiter — whitelist / blacklist', () => {
       expect(result.allowed).toBe(true)
     }
   })
+
+  it('addToWhitelist allows an identifier at runtime without mutating the config', () => {
+    const config: RateLimitConfig = { ...baseConfig, maxAttempts: 1 }
+
+    limiter.addToWhitelist('runtime-vip')
+    const result = limiter.checkLimit('runtime-vip', config)
+
+    expect(result.allowed).toBe(true)
+    expect(result.reason).toBe('whitelisted')
+    // The shared config object must be untouched (HIGH-03 regression guard)
+    expect(config.whitelist).toBeUndefined()
+  })
+
+  it('addToBlacklist denies an identifier at runtime without mutating the config', () => {
+    const config: RateLimitConfig = { ...baseConfig }
+
+    limiter.addToBlacklist('runtime-banned')
+    const result = limiter.checkLimit('runtime-banned', config)
+
+    expect(result.allowed).toBe(false)
+    expect(result.reason).toBe('blacklisted')
+    expect(config.blacklist).toBeUndefined()
+  })
+
+  it('allow/deny are mutually exclusive and removable', () => {
+    const config: RateLimitConfig = { ...baseConfig, maxAttempts: 1 }
+
+    limiter.addToBlacklist('flip')
+    expect(limiter.checkLimit('flip', config).reason).toBe('blacklisted')
+
+    // Promoting to whitelist clears the blacklist entry
+    limiter.addToWhitelist('flip')
+    expect(limiter.checkLimit('flip', config).reason).toBe('whitelisted')
+
+    // Removing from whitelist falls back to normal rate limiting
+    limiter.removeFromWhitelist('flip')
+    const after = limiter.checkLimit('flip', config)
+    expect(after.reason).not.toBe('whitelisted')
+    expect(after.reason).not.toBe('blacklisted')
+  })
 })
 
 describe('RateLimiter — rate limiting', () => {
@@ -294,7 +334,7 @@ describe('RateLimiter — eviction and cleanup', () => {
   })
 
   it('evicts oldest entries when store size reaches MAX_STORE_SIZE', () => {
-    const maxSize = securityConfig.rateLimitMaxHistoryPerClient // 100
+    const maxSize = securityConfig.rateLimitMaxStoreSize // distinct from per-client history cap
 
     // Fill the store to MAX_STORE_SIZE
     for (let i = 0; i < maxSize; i++) {
@@ -308,7 +348,7 @@ describe('RateLimiter — eviction and cleanup', () => {
     limiter.checkLimit('trigger-eviction', baseConfig)
 
     const afterEviction = limiter.exportMetrics()
-    // Store should be reduced — eviction target is 0.8 of MAX_STORE_SIZE = 80, plus the new entry
+    // Store should be reduced — eviction target is EVICTION_TARGET_RATIO of MAX_STORE_SIZE
     expect(afterEviction.activeClients).toBeLessThan(maxSize)
   })
 

--- a/src/lib/__tests__/security.test.ts
+++ b/src/lib/__tests__/security.test.ts
@@ -34,5 +34,18 @@ describe('securityConfig', () => {
     expect(securityConfig.rateLimitMaxRequests).toBeGreaterThan(0)
     expect(securityConfig.rateLimitClientExpiryMs).toBeGreaterThan(0)
     expect(securityConfig.rateLimitMaxHistoryPerClient).toBeGreaterThan(0)
+    expect(securityConfig.rateLimitMaxStoreSize).toBeGreaterThan(0)
+    expect(securityConfig.rateLimitHistoryRetentionMs).toBeGreaterThan(0)
+    expect(securityConfig.rateLimitAbsoluteExpiryMs).toBeGreaterThan(0)
+  })
+
+  it('absolute expiry is a much longer ceiling than the inactivity window', () => {
+    // Invariant the cleanup logic depends on: the createdAt-based hard ceiling
+    // must outlast the lastAttempt-based inactivity sweep, otherwise active
+    // clients' penalties/blocks get wiped every cleanup cycle and the
+    // inactivity branch becomes unreachable.
+    expect(securityConfig.rateLimitAbsoluteExpiryMs).toBeGreaterThan(
+      securityConfig.rateLimitClientExpiryMs
+    )
   })
 })

--- a/src/lib/rate-limiter/store.ts
+++ b/src/lib/rate-limiter/store.ts
@@ -475,34 +475,29 @@ export class RateLimiter implements Disposable {
   }
 
   /**
-   * Evict records that have exceeded absolute expiration time
-   * This ensures no record persists forever regardless of activity
-   */
-  private evictExpiredRecords(): void {
-    const now = Date.now()
-    const expirationThreshold = now - ABSOLUTE_EXPIRATION_MS
-
-    // Iterate over keys to safely delete entries during iteration.
-    // Mutating a Map while iterating over .entries() throws in modern JS engines.
-    for (const key of this.store.keys()) {
-      const record = this.store.get(key)
-      if (record && record.createdAt < expirationThreshold) {
-        // Record has existed longer than absolute expiration - remove it
-        this.store.delete(key)
-      }
-    }
-  }
-
-  /**
-   * Clean up expired entries and reset penalties
+   * Clean up expired entries and reset penalties.
+   *
+   * A single pass over the store collects keys to delete, then batch-deletes
+   * after iterating. Deleting during Map iteration is well-defined and safe in
+   * JS (the iterator simply skips not-yet-visited deleted keys), but the
+   * collect-then-delete idiom keeps every deletion site in this class uniform
+   * (see `enforceStoreSize`).
    */
   private cleanup(): void {
     const now = Date.now()
     const keysToDelete: string[] = []
 
-    this.evictExpiredRecords()
+    // Hard ceiling: a record is dropped once it exceeds absolute expiration,
+    // regardless of recent activity or penalties. Checked first so it takes
+    // precedence over the activity-based conditions below.
+    const absoluteExpirationThreshold = now - ABSOLUTE_EXPIRATION_MS
 
     for (const [key, record] of this.store.entries()) {
+      if (record.createdAt < absoluteExpirationThreshold) {
+        keysToDelete.push(key)
+        continue
+      }
+
       // Remove completely expired records (no activity + no penalties + empty history)
       if (now > record.resetTime && record.penalties === 0 && record.requestHistory.length === 0) {
         keysToDelete.push(key)

--- a/src/lib/rate-limiter/store.ts
+++ b/src/lib/rate-limiter/store.ts
@@ -482,8 +482,11 @@ export class RateLimiter implements Disposable {
     const now = Date.now()
     const expirationThreshold = now - ABSOLUTE_EXPIRATION_MS
 
-    for (const [key, record] of this.store.entries()) {
-      if (record.createdAt < expirationThreshold) {
+    // Iterate over keys to safely delete entries during iteration.
+    // Mutating a Map while iterating over .entries() throws in modern JS engines.
+    for (const key of this.store.keys()) {
+      const record = this.store.get(key)
+      if (record && record.createdAt < expirationThreshold) {
         // Record has existed longer than absolute expiration - remove it
         this.store.delete(key)
       }

--- a/src/lib/rate-limiter/store.ts
+++ b/src/lib/rate-limiter/store.ts
@@ -12,19 +12,32 @@ import type {
 } from '@/types/security'
 import { securityConfig } from '@/lib/security'
 
-// Memory management constants from centralized configuration
-const MAX_STORE_SIZE = securityConfig.rateLimitMaxHistoryPerClient
+// Memory-management constants, each mapped to a DISTINCT security-config field.
+// Previously several aliased the same field, which silently collapsed separate
+// concepts — most consequentially the absolute ceiling onto the 15-min
+// inactivity window, which let an active client's penalties/blocks be wiped
+// every cleanup cycle and made the inactivity sweep unreachable.
+const MAX_STORE_SIZE = securityConfig.rateLimitMaxStoreSize
 const MAX_REQUEST_HISTORY_PER_CLIENT = securityConfig.rateLimitMaxHistoryPerClient
-const REQUEST_HISTORY_RETENTION_MS = securityConfig.rateLimitClientExpiryMs
+const REQUEST_HISTORY_RETENTION_MS = securityConfig.rateLimitHistoryRetentionMs
 const CLIENT_EXPIRY_TIME = securityConfig.rateLimitClientExpiryMs
 const CLEANUP_INTERVAL = 300000 // 5 minutes
-const ABSOLUTE_EXPIRATION_MS = securityConfig.rateLimitClientExpiryMs
+const ABSOLUTE_EXPIRATION_MS = securityConfig.rateLimitAbsoluteExpiryMs
 const EVICTION_BATCH_SIZE = 100
 const EVICTION_TARGET_RATIO = 0.8
+const GLOBAL_LOAD_CACHE_TTL_MS = 1000 // recompute the global-load signal at most once/sec
 
 // Node.js 24: Implements Disposable for automatic cleanup via 'using' keyword
 export class RateLimiter implements Disposable {
   private store = new Map<string, RateLimitRecord>()
+  // Runtime allow/deny lists held as limiter state — never mutate the shared
+  // per-route RateLimitConfig singletons (see addToWhitelist/addToBlacklist).
+  private dynamicWhitelist = new Set<string>()
+  private dynamicBlacklist = new Set<string>()
+  // Cached global-load signal; recomputed at most once per TTL to avoid an
+  // O(store size) scan on every checkLimit call.
+  private cachedGlobalLoad = 0
+  private globalLoadComputedAt = 0
   private analytics: RateLimitAnalytics = {
     totalRequests: 0,
     blockedRequests: 0,
@@ -62,12 +75,12 @@ export class RateLimiter implements Disposable {
   ): RateLimitResult {
     const now = Date.now()
 
-    // Check whitelist/blacklist first
-    if (config.whitelist?.includes(identifier)) {
+    // Check whitelist/blacklist first (per-route config + runtime overrides)
+    if (config.whitelist?.includes(identifier) || this.dynamicWhitelist.has(identifier)) {
       return { allowed: true, reason: 'whitelisted', confidence: 1.0 }
     }
 
-    if (config.blacklist?.includes(identifier)) {
+    if (config.blacklist?.includes(identifier) || this.dynamicBlacklist.has(identifier)) {
       this.analytics.blockedRequests++
       return {
         allowed: false,
@@ -323,9 +336,18 @@ export class RateLimiter implements Disposable {
    * Calculate global system load
    */
   private calculateGlobalLoad(): number {
+    // Cached: this scans the whole store, but checkLimit calls it on every
+    // request. With a large store that would be O(n) per request; recomputing
+    // at most once per second keeps the hot path cheap while the signal (only
+    // used for adaptive thresholds + analytics) stays fresh enough.
+    const now = Date.now()
+    if (now - this.globalLoadComputedAt < GLOBAL_LOAD_CACHE_TTL_MS) {
+      return this.cachedGlobalLoad
+    }
+
     const totalActiveClients = this.store.size
     const recentRequests = Array.from(this.store.values())
-      .map((record) => record.requestHistory.filter((t) => t > Date.now() - 60000).length)
+      .map((record) => record.requestHistory.filter((t) => t > now - 60000).length)
       .reduce((sum, count) => sum + count, 0)
 
     // Normalize to 0-1 scale based on reasonable thresholds
@@ -335,7 +357,10 @@ export class RateLimiter implements Disposable {
     const clientLoad = Math.min(totalActiveClients / maxExpectedClients, 1)
     const requestLoad = Math.min(recentRequests / maxExpectedRPM, 1)
 
-    return (clientLoad + requestLoad) / 2
+    const load = (clientLoad + requestLoad) / 2
+    this.cachedGlobalLoad = load
+    this.globalLoadComputedAt = now
+    return load
   }
 
   /**
@@ -391,20 +416,29 @@ export class RateLimiter implements Disposable {
   }
 
   /**
-   * Add to whitelist/blacklist dynamically
+   * Dynamically allow/deny an identifier at runtime (admin functions).
+   *
+   * These mutate limiter-instance state only — they never touch the shared
+   * per-route RateLimitConfig objects (which are module-level singletons, so
+   * mutating them would leak across every request and could never be undone).
+   * Allow and deny are mutually exclusive: adding to one removes from the other.
    */
-  updateWhitelist(identifier: string, config: RateLimitConfig): void {
-    if (!config.whitelist) config.whitelist = []
-    if (!config.whitelist.includes(identifier)) {
-      config.whitelist.push(identifier)
-    }
+  addToWhitelist(identifier: string): void {
+    this.dynamicBlacklist.delete(identifier)
+    this.dynamicWhitelist.add(identifier)
   }
 
-  updateBlacklist(identifier: string, config: RateLimitConfig): void {
-    if (!config.blacklist) config.blacklist = []
-    if (!config.blacklist.includes(identifier)) {
-      config.blacklist.push(identifier)
-    }
+  addToBlacklist(identifier: string): void {
+    this.dynamicWhitelist.delete(identifier)
+    this.dynamicBlacklist.add(identifier)
+  }
+
+  removeFromWhitelist(identifier: string): void {
+    this.dynamicWhitelist.delete(identifier)
+  }
+
+  removeFromBlacklist(identifier: string): void {
+    this.dynamicBlacklist.delete(identifier)
   }
 
   /**
@@ -481,7 +515,7 @@ export class RateLimiter implements Disposable {
    * after iterating. Deleting during Map iteration is well-defined and safe in
    * JS (the iterator simply skips not-yet-visited deleted keys), but the
    * collect-then-delete idiom keeps every deletion site in this class uniform
-   * (see `enforceStoreSize`).
+   * (see `evictOldestEntries`).
    */
   private cleanup(): void {
     const now = Date.now()
@@ -504,7 +538,7 @@ export class RateLimiter implements Disposable {
         continue
       }
 
-      // Remove records that haven't been active for 24 hours
+      // Remove records idle beyond the client-expiry window (inactivity sweep)
       if (now - record.lastAttempt > CLIENT_EXPIRY_TIME) {
         keysToDelete.push(key)
         continue

--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -28,6 +28,9 @@ export interface SecurityConfig {
   rateLimitMaxRequests: number
   rateLimitClientExpiryMs: number
   rateLimitMaxHistoryPerClient: number
+  rateLimitMaxStoreSize: number
+  rateLimitHistoryRetentionMs: number
+  rateLimitAbsoluteExpiryMs: number
 }
 
 export const securityConfig: SecurityConfig = {
@@ -53,6 +56,17 @@ export const securityConfig: SecurityConfig = {
   // Rate Limiting (per API route)
   rateLimitWindowMs: 60 * 1000, // 1 minute
   rateLimitMaxRequests: 10, // 10 requests per minute
+  // Evict a client's record after this much inactivity (no new attempts).
   rateLimitClientExpiryMs: 15 * 60 * 1000, // 15 minutes
-  rateLimitMaxHistoryPerClient: 100, // Max history entries per client
+  // Max request-timestamp entries retained per client (bounds per-record memory).
+  rateLimitMaxHistoryPerClient: 100,
+  // Max distinct clients tracked before LRU eviction kicks in (bounds total memory).
+  rateLimitMaxStoreSize: 10_000,
+  // How long request timestamps are kept for burst/abuse analysis.
+  rateLimitHistoryRetentionMs: 15 * 60 * 1000, // 15 minutes
+  // Hard ceiling: a record is dropped this long after creation regardless of
+  // activity, so penalties/blocks accrued within the window are no longer reset
+  // on every cleanup cycle. Must be >> rateLimitClientExpiryMs for the
+  // inactivity sweep to remain the dominant eviction path for idle clients.
+  rateLimitAbsoluteExpiryMs: 24 * 60 * 60 * 1000, // 24 hours
 }


### PR DESCRIPTION
Started as a CRIT-01 "fix"; CRIT-01 turned out to be a false positive, and verifying it surfaced several **real, pre-existing** rate-limiter defects. This PR addresses the entire rate-limiter audit scope as one coherent change.

## Context: CRIT-01 was a false positive
Deleting from a native JS `Map` during `.entries()` iteration is spec-safe — it does not throw or corrupt the iterator (verified empirically on Node v26 / Bun 1.3.14). The original loop had no bug. What it *did* have was a redundant second full pass over the store, plus several deeper issues the structure hid.

## What's fixed (all verified against source)

1. **Single-pass `cleanup()`** — folded the redundant `evictExpiredRecords()` pass into the main loop (first/highest-precedence condition), collect-then-batch-delete idiom. One pass, not two.

2. **Absolute-expiration is now a real 24h ceiling, not 15m** — the heart of it. \`ABSOLUTE_EXPIRATION_MS\` was keyed on \`createdAt\` *and equal to the 15-min inactivity window*, so cleanup purged any client first seen >15 min ago **regardless of penalties** — silently resetting active blocks every cycle and defeating progressive penalties and the advertised 30-min \`sensitive\` block. The ceiling is now \`24h >> 15m\`, so blocks persist as designed, and the \`lastAttempt\`-based inactivity sweep (previously **unreachable dead code**) becomes the live path for idle clients. Pinned by an invariant test.

3. **De-conflated constants** (closes #163 / MED-05) — five module constants aliased just two config fields, collapsing distinct concepts. Each now maps to its own intention-named \`securityConfig\` field: \`rateLimitMaxStoreSize\`, \`rateLimitHistoryRetentionMs\`, \`rateLimitAbsoluteExpiryMs\`.

4. **Store-size cap is its own field (10k), not 100** — at 100 the limiter evicted clients under any traffic with >100 distinct IPs, weakening limiting. Now a deliberate memory bound separate from the per-client history cap.

5. **Whitelist/blacklist no longer mutate shared config** (#152 / HIGH-03) — runtime allow/deny lists are held as limiter-instance \`Set\`s, consulted alongside the per-route config, with a mutually-exclusive add/remove API. Regression-guarded by tests asserting the passed config is untouched.

6. **\`calculateGlobalLoad\` cached (1s TTL)** — it scanned the whole store on *every* \`checkLimit\` (O(n)/req → quadratic with a 10k store). The signal only feeds adaptive thresholds + analytics, which tolerate ≤1s staleness.

7. **Comment/doc accuracy** — stale "24 hours" inactivity comment (it's 15m), and the \`evictOldestEntries\` docstring reference.

## Testing
- \`typecheck\` ✓ · \`biome\` ✓
- Full suite **1019 passing** (added whitelist/blacklist runtime + config-invariant tests)

Closes #146 · Closes #163
Related: #152 (latent footgun, now converted to a safe feature)

[hudsor01]