### PR TITLE
fix(logger): remove dead FileTransport stub (#149)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ Sentry vars (`SENTRY_DSN`, `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_ORG`, `SENTRY_PROJE
 
 Three Sentry configs at repo root: `sentry.server.config.ts`, `sentry.client.config.ts`, `sentry.edge.config.ts`. Wrapped via `withSentryConfig(nextConfig, …)` in `next.config.js:187`. Disabled when `NODE_ENV='test'` or DSN absent. Sample rates parsed via local `parseSampleRate()`, clamped `[0,1]`, default `0.1` in prod / `1` in dev. No tunnel route.
 
-Logger (`src/lib/logger.ts`): exports `logger` singleton + `createContextLogger(name)` factory. Levels: `debug`/`info`/`warn`/`error`/`fatal` (controlled by `LOG_LEVEL`). Three transports: `ConsoleTransport` (colored, suppressed in prod), `SentryTransport` (error → `captureException`, warn → `captureMessage`, info/debug → `addBreadcrumb`), `FileTransport` (buffered, flushes every 5s). Lazy-requires `@sentry/nextjs`.
+Logger (`src/lib/logger.ts`): exports `logger` singleton + `createContextLogger(name)` factory. Levels: `debug`/`info`/`warn`/`error`/`fatal` (controlled by `LOG_LEVEL`). Two transports: `ConsoleTransport` (colored, suppressed in prod) and `SentryTransport` (error → `captureException`, warn → `captureMessage`, info/debug → `addBreadcrumb`). Sentry is the production sink — there is no file transport. Lazy-requires `@sentry/nextjs`.
 
 ## Gotchas
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -114,58 +114,6 @@ class SentryTransport implements LogTransport {
   }
 }
 
-// File transport (for persistent logging)
-// Node.js 24: Implements Disposable for automatic cleanup via 'using' keyword
-class FileTransport implements LogTransport, Disposable {
-  private buffer: LogEntry[] = []
-  private readonly maxBufferSize = 100
-  private readonly flushInterval = 5000 // 5 seconds
-  private flushIntervalId: NodeJS.Timeout | null = null
-
-  constructor() {
-    // Flush buffer periodically
-    this.flushIntervalId = setInterval(() => this.flush(), this.flushInterval)
-
-    // Flush on process exit
-    process.on('exit', () => this.flush())
-    process.on('SIGINT', () => this.flush())
-    process.on('SIGTERM', () => this.flush())
-  }
-
-  log(entry: LogEntry): void {
-    if (!shouldLog(entry.level)) return
-
-    this.buffer.push(entry)
-
-    // Flush if buffer is full
-    if (this.buffer.length >= this.maxBufferSize) {
-      this.flush()
-    }
-  }
-
-  private flush(): void {
-    if (this.buffer.length === 0) return
-
-    try {
-      // In a real implementation, you'd write to a file or send to a service
-      // For now, we'll just clear the buffer
-      this.buffer = []
-    } catch (error) {
-      console.error('Failed to flush log buffer:', error)
-    }
-  }
-
-  // Node.js 24: Explicit Resource Management - called automatically with 'using' keyword
-  [Symbol.dispose](): void {
-    if (this.flushIntervalId) {
-      clearInterval(this.flushIntervalId)
-      this.flushIntervalId = null
-    }
-    // Flush remaining logs before disposal
-    this.flush()
-  }
-}
-
 // Main logger implementation
 class LoggerImpl implements Logger {
   private transports: LogTransport[]
@@ -448,13 +396,10 @@ function createLogger(): Logger {
   if (IS_BUILD_PHASE) {
     // During build, no transports — real errors throw and Next.js reports them
   } else if (IS_PRODUCTION) {
-    // In production, route errors/warnings to Sentry, info/debug as breadcrumbs
+    // In production, route errors/warnings to Sentry, info/debug as breadcrumbs.
+    // (Sentry is the production log sink; there is no file transport — the old
+    // FileTransport silently discarded everything it buffered. See #149.)
     transports.push(new SentryTransport())
-
-    // Optionally add file transport for local persistence
-    if (process.env.ENABLE_FILE_LOGGING === 'true') {
-      transports.push(new FileTransport())
-    }
   } else {
     // In development, use colored console output
     transports.push(new ConsoleTransport())


### PR DESCRIPTION
Closes #149.

`FileTransport.flush()` was a placeholder that cleared its buffer without writing anywhere:
```ts
// In a real implementation, you'd write to a file or send to a service
// For now, we'll just clear the buffer
this.buffer = []
```
So with `ENABLE_FILE_LOGGING=true` every buffered entry was **silently discarded**, and each instance also registered a `setInterval` plus `exit`/`SIGINT`/`SIGTERM` handlers.

Verified during the audit re-check: production logging already flows through **`SentryTransport`** (the real sink), and `ENABLE_FILE_LOGGING` is set nowhere — so this was dead, misleading code, not a real persistence path. (The original CRIT-04 "complete loss of prod logs" framing was overstated for that reason; this PR is the cleanup.)

## Change
- Remove the `FileTransport` class and its conditional instantiation in `createLogger()`.
- Production keeps `SentryTransport` only; dev keeps `ConsoleTransport`.
- `CLAUDE.md` updated: "two transports", no file transport.
- `shouldLog` / `LogEntry` remain in use by the other transports.

## Testing
- `typecheck` + `biome` clean; logger suite 21/21; full suite **1061 pass**.

[hudsor01]