### PR TITLE
fix(seo): consolidate cannibalizing blog clusters (GSC indexing)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -162,6 +162,37 @@ const nextConfig = {
       // Legacy URL → home. /github, /linkedin, /twitter live in vercel.json
       // so they redirect at the edge before hitting the Next.js server.
       { source: '/home', destination: '/', permanent: true },
+
+      // Blog de-cannibalization: retire near-duplicate posts into one canonical
+      // pillar per topic so Google indexes a strong page instead of parking the
+      // whole cluster as "Discovered – currently not indexed". 308 (permanent)
+      // consolidates link equity into the keeper. The retired slugs are ALSO
+      // excluded from the sitemap (src/app/sitemap.ts RETIRED_BLOG_SLUGS) so we
+      // never advertise a URL that redirects.
+      // Forecast-accuracy cluster → keeper:
+      {
+        source: '/blog/stop-guessing-how-we-crushed-forecasting-errors-by-34-in-one-quarter',
+        destination: '/blog/stop-guessing-how-we-slashed-forecast-variance-by-34-in-90-days',
+        permanent: true,
+      },
+      {
+        source: '/blog/stop-guessing-how-to-slash-forecast-variance-by-60-in-90-days',
+        destination: '/blog/stop-guessing-how-we-slashed-forecast-variance-by-34-in-90-days',
+        permanent: true,
+      },
+      // Closed-lost / dead-deal reactivation cluster → keeper:
+      {
+        source:
+          '/blog/the-4-2m-you-left-on-the-table-why-your-closed-lost-deals-are-actually-sleeping-',
+        destination: '/blog/the-23-revenue-leak-you-re-ignoring-how-to-resurrect-dead-deals',
+        permanent: true,
+      },
+      {
+        source:
+          '/blog/stop-ignoring-your-dead-opportunities-how-we-revived-4-2m-in-lost-revenue-with-o',
+        destination: '/blog/the-23-revenue-leak-you-re-ignoring-how-to-resurrect-dead-deals',
+        permanent: true,
+      },
     ]
   },
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -34,6 +34,17 @@ const STATIC_LAST_MODIFIED = process.env.VERCEL_GIT_COMMIT_AUTHOR_DATE || new Da
 // emits the string as-is into the XML element value.
 const xmlSafeUrl = (url: string): string => url.replace(/&/g, '&amp;')
 
+// Slugs retired in the blog de-cannibalization cleanup. Each 308-redirects to
+// its canonical keeper in next.config.js, so they must NOT appear in the
+// sitemap — a sitemap URL that redirects is flagged "Page with redirect" in
+// Search Console. Keep in sync with next.config.js `redirects()`.
+const RETIRED_BLOG_SLUGS = new Set<string>([
+  'stop-guessing-how-we-crushed-forecasting-errors-by-34-in-one-quarter',
+  'stop-guessing-how-to-slash-forecast-variance-by-60-in-90-days',
+  'the-4-2m-you-left-on-the-table-why-your-closed-lost-deals-are-actually-sleeping-',
+  'stop-ignoring-your-dead-opportunities-how-we-revived-4-2m-in-lost-revenue-with-o',
+])
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = SITE_ORIGIN
   // fallback only for blog posts with null timestamps
@@ -152,34 +163,36 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     // for the same set of bad rows, drowning real signal.
     const rejectedFeaturedImages: Array<{ slug: string; stored: string }> = []
 
-    blogPages = posts.map((post) => {
-      // safeFeaturedImageUrl re-validates at read time. Shared with
-      // BlogPostJsonLd so sitemap and JSON-LD can never diverge on
-      // what's considered a "safe" image URL for a given post.
-      //
-      // Omit `images` entirely when isFallback=true: the `/api/og`
-      // card is a brand placeholder, not indexable per-post imagery.
-      // Including it in <image:loc> would dilute image-search ranking
-      // (Google indexes the placeholder as the "real" blog image and
-      // serves it for image-search queries that bounce on click).
-      const featured = safeFeaturedImageUrl(post.featuredImage, {
-        title: post.title,
-        subtitle: 'Blog Post',
+    blogPages = posts
+      .filter((post) => !RETIRED_BLOG_SLUGS.has(post.slug))
+      .map((post) => {
+        // safeFeaturedImageUrl re-validates at read time. Shared with
+        // BlogPostJsonLd so sitemap and JSON-LD can never diverge on
+        // what's considered a "safe" image URL for a given post.
+        //
+        // Omit `images` entirely when isFallback=true: the `/api/og`
+        // card is a brand placeholder, not indexable per-post imagery.
+        // Including it in <image:loc> would dilute image-search ranking
+        // (Google indexes the placeholder as the "real" blog image and
+        // serves it for image-search queries that bounce on click).
+        const featured = safeFeaturedImageUrl(post.featuredImage, {
+          title: post.title,
+          subtitle: 'Blog Post',
+        })
+
+        if (featured.isFallback && post.featuredImage) {
+          rejectedFeaturedImages.push({ slug: post.slug, stored: post.featuredImage })
+        }
+
+        return {
+          url: `${baseUrl}/blog/${post.slug}`,
+          lastModified:
+            post.updatedAt?.toISOString() || post.publishedAt?.toISOString() || fallbackDate,
+          changeFrequency: 'monthly' as const,
+          priority: 0.7,
+          ...(featured.isFallback ? {} : { images: [xmlSafeUrl(featured.url)] }),
+        }
       })
-
-      if (featured.isFallback && post.featuredImage) {
-        rejectedFeaturedImages.push({ slug: post.slug, stored: post.featuredImage })
-      }
-
-      return {
-        url: `${baseUrl}/blog/${post.slug}`,
-        lastModified:
-          post.updatedAt?.toISOString() || post.publishedAt?.toISOString() || fallbackDate,
-        changeFrequency: 'monthly' as const,
-        priority: 0.7,
-        ...(featured.isFallback ? {} : { images: [xmlSafeUrl(featured.url)] }),
-      }
-    })
 
     // Distinguish 'never had a featured image' (null stored, silent
     // skip) from 'had one but it failed schema re-validation'


### PR DESCRIPTION
## Why
Search Console flagged **41 "Discovered – currently not indexed"** pages. After a full diagnosis, **there is no technical SEO bug** — the cause is **keyword cannibalization**.

Verified healthy: all 52 sitemap URLs → 200, every page has a correct self-canonical + `index,follow`, `www`/trailing/`http` canonicalization works, robots + `Sitemap:` correct. The "Server error (5xx) ×2" are the already-fixed `isomorphic-dompurify` `/blog/[slug]` 500s (awaiting GSC re-validation); the "Page with redirect ×3" are intentional vanity redirects.

The real issue: two clusters of near-identical long-form posts (analyzed all 9 bodies) targeting the same query, so Google indexes one per cluster and parks the rest.

## Change (reversible, code-only)
- **`next.config.js`** — 4 × 308 permanent redirects, retired → canonical keeper (consolidates link equity into the pillar).
- **`sitemap.ts`** — `RETIRED_BLOG_SLUGS` excludes them so we never advertise a redirecting URL.

| Retired (near-dupe) | → Keeper |
|---|---|
| `...crushed-forecasting-errors-by-34-in-one-quarter` | `...slashed-forecast-variance-by-34-in-90-days` |
| `...slash-forecast-variance-by-60-in-90-days` | `...slashed-forecast-variance-by-34-in-90-days` |
| `the-4-2m-you-left-on-the-table-...-sleeping-` | `the-23-revenue-leak-...-resurrect-dead-deals` |
| `stop-ignoring-your-dead-opportunities-...-with-o` | `the-23-revenue-leak-...-resurrect-dead-deals` |

**Kept (distinct intent):** Clari/revenue-intelligence-platform forecast post, first-RevOps-hire post, ZoomInfo/Salesloft-tooling post.

## Not in this PR
- **DB unpublish** of the 4 retired rows (so they also drop from on-site `/blog` listings + related-reading — today their cards still render and 308 on click). Recommended follow-up.
- **GSC actions:** click *Validate Fix* on Server error (5xx); request indexing for priority URLs after merge.

## Testing
Build + typecheck + biome clean; full suite **1061 pass**.

[hudsor01]