### PR TITLE
chore(footer): drop noreferrer on Hudson Digital Solutions backlink

### DIFF
--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -9,7 +9,12 @@ export function Footer() {
           <a
             href="https://hudsondigitalsolutions.com"
             target="_blank"
-            rel="noopener noreferrer"
+            // Intentionally `noopener` only (not `noreferrer`): this is an owned
+            // cross-promotion link to the business site, and keeping the Referer
+            // header lets Hudson Digital Solutions' analytics attribute the
+            // referral traffic from here. `noopener` still closes the
+            // window.opener security hole.
+            rel="noopener"
             className="hover:text-primary transition-colors"
           >
             Built by Hudson Digital Solutions


### PR DESCRIPTION
The sitewide footer link to **hudsondigitalsolutions.com** used `rel="noopener noreferrer"`. `noreferrer` strips the `Referer` header, so HDS's analytics couldn't attribute the referral traffic this site sends it.

Change: `rel="noopener noreferrer"` → `rel="noopener"`.
- Keeps `noopener` (closes the `window.opener` security hole).
- Drops `noreferrer` so HDS analytics can credit referrals from richardwhudsonjr.com.
- Link stays **followed** (no `nofollow`) — still passes link equity to the business site.

Note: it's an owned cross-promotion link, so this is intentional/legitimate. Sitewide links are still consolidated by Google (≈one link's worth of equity, not one-per-page) — the real authority lift for HDS comes from external/independent backlinks.

typecheck + biome clean.

[hudsor01]