### PR TITLE
chore: remove verified dead code + redundant casts (9 audit issues)

### DIFF
--- a/src/lib/__tests__/route-utils.test.ts
+++ b/src/lib/__tests__/route-utils.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect } from 'vitest'
-import { asRoute, getRouteKey, routeArray, routeRecord } from '@/lib/route-utils'
+import { asRoute, getRouteKey } from '@/lib/route-utils'
 
 describe('asRoute', () => {
   it('returns the input string verbatim (typed as Route)', () => {
@@ -20,19 +20,5 @@ describe('getRouteKey', () => {
   it('returns fallback when route is neither', () => {
     expect(getRouteKey(undefined as never, 'fb')).toBe('fb')
     expect(getRouteKey(null as never, 'fb')).toBe('fb')
-  })
-})
-
-describe('routeArray', () => {
-  it('maps every path through asRoute', () => {
-    expect(routeArray(['/a', '/b'])).toEqual(['/a', '/b'])
-  })
-})
-
-describe('routeRecord', () => {
-  it('preserves keys and converts each value', () => {
-    const r = routeRecord({ home: '/', about: '/about' })
-    expect(r.home).toBe('/')
-    expect(r.about).toBe('/about')
   })
 })

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect } from 'vitest'
 import { z } from 'zod'
 import {
   cn,
-  formatProjectName,
   truncate,
   formatRelativeTime,
   generateId,
@@ -12,14 +11,10 @@ import {
   safeJsonParse,
   escapeRegExp,
   createUrl,
-  formatData,
   smartMerge,
   isServer,
   isClient,
-  delay,
   absoluteUrlTestable,
-  getCurrentBreakpointTestable,
-  isInViewportTestable,
 } from '@/lib/utils'
 
 describe('cn', () => {
@@ -34,16 +29,6 @@ describe('cn', () => {
 
   it('handles arrays/falsy values', () => {
     expect(cn('a', false && 'b', null, undefined, ['c', 'd'])).toBe('a c d')
-  })
-})
-
-describe('formatProjectName', () => {
-  it('converts kebab-case to Title Case', () => {
-    expect(formatProjectName('my-cool-project')).toBe('My Cool Project')
-  })
-
-  it('handles single word', () => {
-    expect(formatProjectName('single')).toBe('Single')
   })
 })
 
@@ -178,15 +163,6 @@ describe('createUrl', () => {
   })
 })
 
-describe('formatData', () => {
-  it('wraps data in { formatted, timestamp }', () => {
-    const r = formatData({ x: 1 })
-    expect(r.formatted).toEqual({ x: 1 })
-    expect(typeof r.timestamp).toBe('string')
-    expect(() => new Date(r.timestamp)).not.toThrow()
-  })
-})
-
 describe('smartMerge', () => {
   it('prefers remote value when local is empty', () => {
     expect(smartMerge({ a: '', b: 'local' }, { a: 'remote', b: 'remote' })).toEqual({
@@ -214,14 +190,6 @@ describe('environment flags (Node test env)', () => {
   })
 })
 
-describe('delay', () => {
-  it('resolves after the specified ms', async () => {
-    const start = Date.now()
-    await delay(20)
-    expect(Date.now() - start).toBeGreaterThanOrEqual(15)
-  })
-})
-
 describe('absoluteUrlTestable', () => {
   it('uses windowObj.location.origin when present', () => {
     const fakeWin = { location: { origin: 'https://test.com' } } as unknown as typeof window
@@ -231,36 +199,5 @@ describe('absoluteUrlTestable', () => {
   it('falls back to env / hardcoded when no window', () => {
     const r = absoluteUrlTestable('/p')
     expect(r.endsWith('/p')).toBe(true)
-  })
-})
-
-describe('getCurrentBreakpointTestable', () => {
-  it('returns md when no window', () => {
-    expect(getCurrentBreakpointTestable()).toBe('md')
-  })
-
-  it('classifies xs at 320px', () => {
-    expect(getCurrentBreakpointTestable({ innerWidth: 320 } as typeof window)).toBe('xs')
-  })
-
-  it('classifies 2xl at 1600px', () => {
-    expect(getCurrentBreakpointTestable({ innerWidth: 1600 } as typeof window)).toBe('2xl')
-  })
-})
-
-describe('isInViewportTestable', () => {
-  it('returns false without window', () => {
-    const fakeEl = {
-      getBoundingClientRect: () => ({ top: 0, bottom: 100, left: 0, right: 100 }),
-    } as unknown as HTMLElement
-    expect(isInViewportTestable(fakeEl)).toBe(false)
-  })
-
-  it('returns true when element rect is inside window', () => {
-    const fakeEl = {
-      getBoundingClientRect: () => ({ top: 10, bottom: 100, left: 10, right: 100 }),
-    } as unknown as HTMLElement
-    const fakeWin = { innerHeight: 800, innerWidth: 600 } as typeof window
-    expect(isInViewportTestable(fakeEl, 0, fakeWin)).toBe(true)
   })
 })

--- a/src/lib/data-service/generators/lead-attribution.ts
+++ b/src/lib/data-service/generators/lead-attribution.ts
@@ -1,8 +1,6 @@
 import type { LeadAttributionData } from '@/types/analytics'
 
-export function generateLeadAttributionData(
-  _baseMetrics: Map<string, number>
-): LeadAttributionData[] {
+export function generateLeadAttributionData(): LeadAttributionData[] {
   const sources = [
     { name: 'Website', traffic_quality: 0.8, cost_factor: 0.3 },
     { name: 'Referrals', traffic_quality: 0.95, cost_factor: 0.1 },

--- a/src/lib/data-service/generators/lead-trends.ts
+++ b/src/lib/data-service/generators/lead-trends.ts
@@ -1,9 +1,6 @@
 import type { LeadTrendData } from '@/types/analytics'
 
-export function generateLeadTrendData(
-  _baseMetrics: Map<string, number>,
-  monthsCount: number = 12
-): LeadTrendData[] {
+export function generateLeadTrendData(monthsCount: number = 12): LeadTrendData[] {
   const data: LeadTrendData[] = []
   const baseLeads = 950
   const baseConversionRate = 0.12

--- a/src/lib/data-service/generators/top-partners.ts
+++ b/src/lib/data-service/generators/top-partners.ts
@@ -1,9 +1,6 @@
 import type { TopPartnerData } from '@/types/analytics'
 
-export function generateTopPartnersData(
-  _baseMetrics: Map<string, number>,
-  count: number = 15
-): TopPartnerData[] {
+export function generateTopPartnersData(count: number = 15): TopPartnerData[] {
   const partnerNames = [
     'Enterprise Solutions Inc',
     'Tech Innovations LLC',

--- a/src/lib/data-service/service.ts
+++ b/src/lib/data-service/service.ts
@@ -52,7 +52,7 @@ export class AnalyticsDataService {
     }
 
     logger.info('Generating lead attribution data')
-    const data = generateLeadAttributionData(BASE_METRICS)
+    const data = generateLeadAttributionData()
 
     if (useCache) {
       this.cache.set(cacheKey, data, 15 * 60 * 1000) // Cache for 15 minutes
@@ -70,7 +70,7 @@ export class AnalyticsDataService {
     }
 
     logger.info('Generating lead trend data', { months })
-    const data = generateLeadTrendData(BASE_METRICS, months)
+    const data = generateLeadTrendData(months)
 
     if (useCache) {
       this.cache.set(cacheKey, data, 10 * 60 * 1000)
@@ -130,7 +130,7 @@ export class AnalyticsDataService {
     }
 
     logger.info('Generating top partners data', { count })
-    const data = generateTopPartnersData(BASE_METRICS, count)
+    const data = generateTopPartnersData(count)
 
     if (useCache) {
       this.cache.set(cacheKey, data, 15 * 60 * 1000) // Cache for 15 minutes

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -16,9 +16,8 @@ const LOG_LEVELS: Record<LogLevel, number> = {
 
 // Environment configuration
 const LOG_LEVEL =
-  (process.env.LOG_LEVEL as LogLevel) ||
-  ((process.env.NODE_ENV as string) === 'production' ? 'info' : 'debug')
-const IS_PRODUCTION = (process.env.NODE_ENV as string) === 'production'
+  (process.env.LOG_LEVEL as LogLevel) || (process.env.NODE_ENV === 'production' ? 'info' : 'debug')
+const IS_PRODUCTION = process.env.NODE_ENV === 'production'
 const IS_BUILD_PHASE = process.env.NEXT_PHASE === 'phase-production-build'
 
 // Shared utility to determine if a log entry should be logged
@@ -38,7 +37,7 @@ class ConsoleTransport implements LogTransport {
   }
 
   log(entry: LogEntry): void {
-    if (!shouldLog(entry.level) || (process.env.NODE_ENV as string) === 'production') return
+    if (!shouldLog(entry.level) || process.env.NODE_ENV === 'production') return
 
     const color = this.colors[entry.level]
     const timestamp = new Date(entry.timestamp).toISOString()
@@ -50,17 +49,14 @@ class ConsoleTransport implements LogTransport {
       output += `\n  Context: ${JSON.stringify(entry.context, null, 2)}`
     }
 
+    // ConsoleTransport only runs in non-production (guarded by the production
+    // early-return above, and production uses SentryTransport), so always
+    // include full error details for debugging. The previous `if (production)`
+    // branch here was unreachable dead code, masked by an `as string` cast.
     if (entry.error) {
-      if ((process.env.NODE_ENV as string) === 'production') {
-        // In production, only log error name and sanitized message
-        output += `\n  Error: ${entry.error.name}: ${entry.error.message}`
-        // Don't include stack traces in production logs to prevent information disclosure
-      } else {
-        // In development, include full error details for debugging
-        output += `\n  Error: ${entry.error.name}: ${entry.error.message}`
-        if (entry.error.stack && entry.level === 'error') {
-          output += `\n  Stack: ${entry.error.stack}`
-        }
+      output += `\n  Error: ${entry.error.name}: ${entry.error.message}`
+      if (entry.error.stack && entry.level === 'error') {
+        output += `\n  Stack: ${entry.error.stack}`
       }
     }
 

--- a/src/lib/route-utils.ts
+++ b/src/lib/route-utils.ts
@@ -20,27 +20,3 @@ export function getRouteKey(route: NextLinkHref, fallback: string | number): str
   }
   return String(fallback)
 }
-
-/**
- * Convert all string paths in an array to Next.js Routes
- */
-export function routeArray(paths: string[]): Route<string>[] {
-  return paths.map((path) => asRoute(path))
-}
-
-/**
- * Convert routes in a record to Next.js Routes
- */
-export function routeRecord<T extends Record<string, string>>(
-  routes: T
-): Record<keyof T, Route<string>> {
-  const result: Record<string, Route<string>> = {}
-
-  // Use Object.entries to ensure we have string keys
-  Object.entries(routes).forEach(([key, value]) => {
-    // Now we're explicitly using string keys
-    result[key] = asRoute(value)
-  })
-
-  return result as Record<keyof T, Route<string>>
-}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -33,17 +33,6 @@ export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(...inputs))
 }
 
-export function formatProjectName(name: string): string {
-  return name
-    .split('-')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ')
-}
-
-export function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
 export const isServer = typeof window === 'undefined'
 export const isClient = !isServer
 
@@ -68,33 +57,6 @@ export function formatRelativeTime(date: string | Date): string {
   const diffInMonths = Math.floor(diffInDays / 30)
   if (diffInMonths < 12) return rtf.format(-diffInMonths, 'month')
   return rtf.format(-Math.floor(diffInMonths / 12), 'year')
-}
-
-export type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl'
-
-export function getCurrentBreakpoint(): Breakpoint {
-  if (isServer) return 'md'
-
-  const width = window.innerWidth
-  if (width < 640) return 'xs'
-  if (width < 768) return 'sm'
-  if (width < 1024) return 'md'
-  if (width < 1280) return 'lg'
-  if (width < 1536) return 'xl'
-  return '2xl'
-}
-
-// Testable version that accepts window object for testing
-export function getCurrentBreakpointTestable(windowObj?: typeof window): Breakpoint {
-  if (!windowObj || typeof windowObj === 'undefined') return 'md'
-
-  const width = windowObj.innerWidth
-  if (width < 640) return 'xs'
-  if (width < 768) return 'sm'
-  if (width < 1024) return 'md'
-  if (width < 1280) return 'lg'
-  if (width < 1536) return 'xl'
-  return '2xl'
 }
 
 export function generateId(length = 8): string {
@@ -157,35 +119,6 @@ export function escapeRegExp(input: string): string {
   return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
-export function isInViewport(element: HTMLElement, offset = 0): boolean {
-  if (isServer) return false
-
-  const rect = element.getBoundingClientRect()
-  return (
-    rect.top <= window.innerHeight + offset &&
-    rect.bottom >= -offset &&
-    rect.left <= window.innerWidth + offset &&
-    rect.right >= -offset
-  )
-}
-
-// Testable version that accepts window object for testing
-export function isInViewportTestable(
-  element: HTMLElement,
-  offset = 0,
-  windowObj?: typeof window
-): boolean {
-  if (!windowObj || typeof windowObj === 'undefined') return false
-
-  const rect = element.getBoundingClientRect()
-  return (
-    rect.top <= windowObj.innerHeight + offset &&
-    rect.bottom >= -offset &&
-    rect.left <= windowObj.innerWidth + offset &&
-    rect.right >= -offset
-  )
-}
-
 export function createUrl(
   pathname: string,
   params: Record<string, string | number | boolean | undefined>
@@ -202,19 +135,6 @@ export type InputChangeEvent = ChangeEvent<HTMLInputElement>
 export type TextAreaChangeEvent = ChangeEvent<HTMLTextAreaElement>
 export type SelectChangeEvent = ChangeEvent<HTMLSelectElement>
 export type FormSubmitEvent = FormEvent<HTMLFormElement>
-
-// Generic data formatter with proper typing
-export interface FormattedData<T> {
-  formatted: T
-  timestamp: string
-}
-
-export function formatData<T>(data: T): FormattedData<T> {
-  return {
-    formatted: data,
-    timestamp: new Date().toISOString(),
-  }
-}
 
 /**
  * Smart merge two records intelligently

--- a/src/types/resume.ts
+++ b/src/types/resume.ts
@@ -171,10 +171,3 @@ export const resume: ResumeData = {
     },
   ],
 }
-
-/**
- * Helper function to get resume data
- */
-export function getResumeData(): ResumeData {
-  return resume
-}


### PR DESCRIPTION
Batch cleanup of the remaining low-severity audit findings. **Each symbol was re-verified as genuinely unused** before removal (grepped across `src/` — no repeat of the LOW-05/06 false positives that were actually in use).

## Dead exports removed (+ their tests)
- `utils.ts`: `formatProjectName` (#159), `formatData` + `FormattedData` (#160), `getCurrentBreakpoint` + `getCurrentBreakpointTestable` + `Breakpoint` type (#161), `delay` (#181), `isInViewport` + `isInViewportTestable` (#182)
- `types/resume.ts`: `getResumeData` (#179)
- `route-utils.ts`: `routeRecord` + `routeArray` (#180)

## Unused params (#162)
- `generators/{lead-attribution,lead-trends,top-partners}` dropped the never-used `_baseMetrics` first param; updated the 3 call sites in `service.ts`.

## Redundant NODE_ENV casts (#175) — with a real find
Dropped `(process.env.NODE_ENV as string)` in 4 places in `logger.ts`. Removing it in `ConsoleTransport.log` surfaced **TS2367**: the inner `if (NODE_ENV === 'production')` branch is **unreachable** — the method already early-returns on production, and production uses `SentryTransport`. The cast was *masking dead code*, not merely redundant. Removed the dead branch instead of restoring the cast.

## Also
Removed the one-off `scripts/retire-blog-posts.ts` (its prod soft-delete is already applied).

## Testing
typecheck + biome clean; full suite **1050 pass** (1061 − 11 tests for the removed functions).

Closes #159, #160, #161, #162, #175, #179, #180, #181, #182

[hudsor01]