### PR TITLE
chore(analytics): dead helper removal + getAllAnalyticsData de-dup lock

### DIFF
--- a/src/hooks/__tests__/use-page-analytics.test.ts
+++ b/src/hooks/__tests__/use-page-analytics.test.ts
@@ -12,7 +12,7 @@ vi.mock('@/lib/logger', () => ({
   },
 }))
 
-import { usePageAnalytics, usePageAnalyticsData } from '@/hooks/use-page-analytics'
+import { usePageAnalytics } from '@/hooks/use-page-analytics'
 
 let fetchSpy: ReturnType<typeof vi.spyOn>
 
@@ -68,19 +68,5 @@ describe('usePageAnalytics', () => {
       window.dispatchEvent(new Event('beforeunload'))
     })
     expect(beaconSpy).toHaveBeenCalled()
-  })
-})
-
-describe('usePageAnalyticsData', () => {
-  it('returns an analyticsUrl with type + slug', () => {
-    const { result } = renderHook(() => usePageAnalyticsData('blog', 'my-slug'))
-    expect(result.current.analyticsUrl).toContain('type=blog')
-    expect(result.current.analyticsUrl).toContain('slug=my-slug')
-  })
-
-  it('omits slug param when undefined', () => {
-    const { result } = renderHook(() => usePageAnalyticsData('project'))
-    expect(result.current.analyticsUrl).toContain('type=project')
-    expect(result.current.analyticsUrl).not.toContain('slug=')
   })
 })

--- a/src/hooks/use-page-analytics.ts
+++ b/src/hooks/use-page-analytics.ts
@@ -179,20 +179,3 @@ function trackEngagement(data: ViewTrackingData) {
     handleAnalyticsError(error, 'trackEngagement')
   }
 }
-
-/**
- * Hook to get analytics data for a specific page
- */
-export function usePageAnalyticsData(type: 'blog' | 'project', slug?: string) {
-  const baseUrl =
-    process.env.NODE_ENV === 'production' ? 'https://richardwhudsonjr.com' : 'http://localhost:3000'
-
-  const params = new URLSearchParams({ type })
-  if (slug) params.append('slug', slug)
-
-  const url = `${baseUrl}/api/analytics/views?${params.toString()}`
-
-  // This would typically use SWR or React Query for caching
-  // For now, return the URL that can be fetched manually
-  return { analyticsUrl: url }
-}

--- a/src/lib/data-service/service.ts
+++ b/src/lib/data-service/service.ts
@@ -20,6 +20,12 @@ import { DataCacheService, type CacheStats } from './cache'
 // Main analytics data service
 export class AnalyticsDataService {
   private cache: DataCacheService
+  // In-flight de-duplication for getAllAnalyticsData: concurrent cache-miss
+  // callers share one generation pass instead of each regenerating. The
+  // `await Promise.all` in the generator yields the event loop between the
+  // cache read and write, so without this two overlapping requests would
+  // double-generate the bundle.
+  private inFlightAll: Promise<AllAnalyticsDataBundle> | null = null
 
   constructor() {
     this.cache = new DataCacheService()
@@ -149,6 +155,16 @@ export class AnalyticsDataService {
       return cached
     }
 
+    // Coalesce concurrent cache-miss callers onto a single generation pass.
+    if (this.inFlightAll) return this.inFlightAll
+
+    this.inFlightAll = this.generateAllAnalyticsData(cacheKey).finally(() => {
+      this.inFlightAll = null
+    })
+    return this.inFlightAll
+  }
+
+  private async generateAllAnalyticsData(cacheKey: string): Promise<AllAnalyticsDataBundle> {
     logger.info('Generating complete analytics dataset')
 
     const [churn, leadAttribution, leadTrends, growth, yearOverYear, topPartners] =


### PR DESCRIPTION
Two more verified audit items.

**#154 (HIGH-05)** — removed the dead `usePageAnalyticsData` helper (referenced only by its own test). It hardcoded a `prod ? richardwhudsonjr.com : localhost` base URL that would break in Vercel preview deploys, but the actual tracking hook `usePageAnalytics` already posts to the relative `/api/analytics/views`, so nothing in the app used it. Deleted the helper + its test.

**#170 (MED-12)** — added an in-flight-promise lock to `getAllAnalyticsData`. It's the only method with an `await Promise.all` *between* the cache read and write, so two concurrent cache-miss callers could each regenerate the whole bundle. They now coalesce onto a single generation pass (the promise is cleared on settle). The individual `getX` methods generate synchronously with no await between get/set, so they're race-free already.

typecheck + biome clean; full suite **1048 pass**.

Closes #154
Closes #170