### PR TITLE
fix(blog,seo): soft-delete filter on /blog index + de-dup About title (#118, #137)

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -66,7 +66,7 @@ SalesLoft Admin certified (Level 1 & 2), HubSpot Revenue Operations certified, a
 
 export const dynamic = 'force-static'
 export const metadata: Metadata = generateMetadata(
-  'About Richard Hudson | Revenue Operations Professional | Dallas-Fort Worth',
+  'About — Revenue Operations Professional',
   'Richard Hudson - Dallas, Texas Revenue Operations Professional serving Dallas-Fort Worth metroplex with 10+ years experience. SalesLoft Admin certified (Level 1 & 2) and HubSpot Revenue Operations certified. Partnership program implementation specialist with system integration experience. Expert in data analytics, process automation, and CRM optimization. $4.8M+ revenue generated across 10+ projects, 432% transaction growth achieved.',
   '/about'
 )

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -6,7 +6,7 @@ import { BlogList } from './_components/blog-list'
 import { BlogJsonLd } from '@/components/seo/blog-json-ld'
 import { BreadcrumbListJsonLd } from '@/components/seo/json-ld/breadcrumb-json-ld'
 import { ItemListJsonLd } from '@/components/seo/json-ld/item-list-json-ld'
-import { desc, eq } from 'drizzle-orm'
+import { and, desc, eq, isNull } from 'drizzle-orm'
 import { db } from '@/lib/db'
 import { blogPosts, categories as categoriesTable } from '@/db/schema'
 import { transformToBlogPostData } from '@/lib/api-blog'
@@ -63,7 +63,9 @@ const getBlogPosts = cache(async (): Promise<BlogPostData[]> => {
 
   try {
     const posts = await db.query.blogPosts.findMany({
-      where: eq(blogPosts.status, 'PUBLISHED'),
+      // Exclude soft-deleted posts so retired/consolidated dupes (which
+      // 308-redirect at the detail level) don't still render as index cards.
+      where: and(eq(blogPosts.status, 'PUBLISHED'), isNull(blogPosts.deletedAt)),
       with: {
         author: true,
         category: true,


### PR DESCRIPTION
**#118** — the `/blog` index query filtered only `status='PUBLISHED'`, missing the `isNull(deletedAt)` filter the category page + generateStaticParams already use. So the retired/consolidated 'Stop Guessing' duplicate (soft-deleted + 308-redirecting) still showed as an index card linking to a redirect. Added the filter — completes the #188 + DB soft-delete consolidation.

**#137** — About passed a title already containing 'Richard Hudson' into `generateMetadata`, whose `%s | Richard Hudson` template doubled it (and made it browser-truncating long). Shortened to `'About — Revenue Operations Professional'`. (404 titles were already consistent per triage.)

typecheck + biome + build clean; full suite passing.

Closes #118
Closes #137