### PR TITLE
chore(security): enforce noDangerouslySetInnerHtml with justified ignores (#174)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -48,7 +48,7 @@
         "noArrayIndexKey": "off"
       },
       "security": {
-        "noDangerouslySetInnerHtml": "off"
+        "noDangerouslySetInnerHtml": "error"
       },
       "correctness": {
         "noUnusedVariables": {

--- a/src/app/blog/_components/blog-post-article.tsx
+++ b/src/app/blog/_components/blog-post-article.tsx
@@ -187,6 +187,7 @@ export function BlogPostArticle({
       return (
         <div
           key={index}
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: blog HTML from trusted token-gated DB, sanitized client-side via DOMPurify
           dangerouslySetInnerHTML={{ __html: sanitizeHtml(part, DOMPURIFY_INLINE_CONFIG) }}
           className="prose prose-lg dark:prose-invert max-w-none"
         />
@@ -225,6 +226,7 @@ export function BlogPostArticle({
       {contentType === 'MARKDOWN' ? (
         renderMarkdownWithCodeBlocks(processedContent)
       ) : (
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: blog HTML from trusted token-gated DB, sanitized client-side via DOMPurify
         <div dangerouslySetInnerHTML={{ __html: sanitizedContent }} />
       )}
     </div>

--- a/src/components/seo/json-ld-script.tsx
+++ b/src/components/seo/json-ld-script.tsx
@@ -18,6 +18,7 @@ export function JsonLdScript({ json, nonce }: JsonLdScriptProps) {
     <script
       type="application/ld+json"
       nonce={nonce ?? undefined}
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: server-generated JSON-LD escaped by safeJsonLdStringify (</script breakout prevented); Next.js official JSON-LD pattern, no user input
       dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(json) }}
     />
   )

--- a/src/components/seo/json-ld/breadcrumb-json-ld.tsx
+++ b/src/components/seo/json-ld/breadcrumb-json-ld.tsx
@@ -22,6 +22,7 @@ export function BreadcrumbListJsonLd({
     <script
       type="application/ld+json"
       nonce={nonce ?? undefined}
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: server-generated JSON-LD escaped by safeJsonLdStringify (</script breakout prevented); Next.js official JSON-LD pattern, no user input
       dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(jsonLd) }}
     />
   )

--- a/src/components/seo/json-ld/faq-json-ld.tsx
+++ b/src/components/seo/json-ld/faq-json-ld.tsx
@@ -24,6 +24,7 @@ export function FAQPageJsonLd({
     <script
       type="application/ld+json"
       nonce={nonce ?? undefined}
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: server-generated JSON-LD escaped by safeJsonLdStringify (</script breakout prevented); Next.js's official JSON-LD pattern, no user input
       dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(jsonLd) }}
     />
   )

--- a/src/components/seo/json-ld/item-list-json-ld.tsx
+++ b/src/components/seo/json-ld/item-list-json-ld.tsx
@@ -40,6 +40,7 @@ export function ItemListJsonLd({
     <script
       type="application/ld+json"
       nonce={nonce ?? undefined}
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: server-generated JSON-LD escaped by safeJsonLdStringify (</script breakout prevented); Next.js official JSON-LD pattern, no user input
       dangerouslySetInnerHTML={{ __html: html }}
     />
   )

--- a/src/components/seo/json-ld/navigation-json-ld.tsx
+++ b/src/components/seo/json-ld/navigation-json-ld.tsx
@@ -18,6 +18,7 @@ export function NavigationJsonLd({ nonce }: { nonce?: string | null }) {
     <script
       type="application/ld+json"
       nonce={nonce ?? undefined}
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: server-generated JSON-LD escaped by safeJsonLdStringify (</script breakout prevented); Next.js official JSON-LD pattern, no user input
       dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(jsonLd) }}
     />
   )

--- a/src/components/seo/json-ld/person-json-ld.tsx
+++ b/src/components/seo/json-ld/person-json-ld.tsx
@@ -123,6 +123,7 @@ export function PersonJsonLd({ nonce }: { nonce?: string | null }) {
     <script
       type="application/ld+json"
       nonce={nonce ?? undefined}
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: server-generated JSON-LD escaped by safeJsonLdStringify (</script breakout prevented); Next.js official JSON-LD pattern, no user input
       dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(jsonLd) }}
     />
   )

--- a/src/components/seo/json-ld/professional-service-json-ld.tsx
+++ b/src/components/seo/json-ld/professional-service-json-ld.tsx
@@ -77,6 +77,7 @@ export function ProfessionalServiceJsonLd({ nonce }: { nonce?: string | null }) 
     <script
       type="application/ld+json"
       nonce={nonce ?? undefined}
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: server-generated JSON-LD escaped by safeJsonLdStringify (</script breakout prevented); Next.js official JSON-LD pattern, no user input
       dangerouslySetInnerHTML={{ __html: html }}
     />
   )

--- a/src/components/seo/json-ld/project-json-ld.tsx
+++ b/src/components/seo/json-ld/project-json-ld.tsx
@@ -78,6 +78,7 @@ export function ProjectJsonLd({
     <script
       type="application/ld+json"
       nonce={nonce ?? undefined}
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: server-generated JSON-LD escaped by safeJsonLdStringify (</script breakout prevented); Next.js official JSON-LD pattern, no user input
       dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(jsonLd) }}
     />
   )

--- a/src/components/seo/json-ld/website-json-ld.tsx
+++ b/src/components/seo/json-ld/website-json-ld.tsx
@@ -36,6 +36,7 @@ export function WebsiteJsonLd({ nonce }: { nonce?: string | null }) {
     <script
       type="application/ld+json"
       nonce={nonce ?? undefined}
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: server-generated JSON-LD escaped by safeJsonLdStringify (</script breakout prevented); Next.js official JSON-LD pattern, no user input
       dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(jsonLd) }}
     />
   )

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -150,6 +150,7 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartThemeConfig }) =>
 
   return (
     <style
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: server-generated CSS custom properties for chart theming, no user input
       dangerouslySetInnerHTML={{
         __html: Object.entries(THEMES)
           .map(

--- a/src/components/ui/orbiting-circles.tsx
+++ b/src/components/ui/orbiting-circles.tsx
@@ -42,6 +42,7 @@ export function OrbitingCircles({
   const calculatedDuration = duration / speed
   return (
     <>
+      {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static computed CSS keyframes, no user input */}
       <style dangerouslySetInnerHTML={{ __html: orbitKeyframes }} />
       {path && (
         <svg


### PR DESCRIPTION
Flips biome's `lint/security/noDangerouslySetInnerHtml` from `off` → **`error`** and documents each of the 12 legitimate usages with a justified `// biome-ignore`. New *unjustified* usages are now caught; the existing safe ones are kept (and explained).

- **JSON-LD** (9 sites) — server-generated, escaped by `safeJsonLdStringify` (`</script` breakout prevented), Next.js's official pattern. No SSR-safe alternative.
- **blog-post-article** (×2) — trusted DB HTML, DOMPurify-sanitized client-side.
- **chart.tsx / orbiting-circles.tsx** — server-generated CSS.

This doubles as the canonical record for the **Aikido** findings: the code is correct/safe, so those should be **suppressed as false-positives**, not changed (the `useEffect` 'autofix' breaks SSR JSON-LD).

`biome check src` + typecheck + full suite clean. No behavior change.

Closes #174