### PR TITLE
fix(projects): duplicate headings, filter reset, index heading (#117,#126,#132)

### DIFF
--- a/src/app/projects/_components/projects-page-content.tsx
+++ b/src/app/projects/_components/projects-page-content.tsx
@@ -7,6 +7,7 @@ import { ProjectStats } from '@/components/projects/project-stats'
 import { ProjectCTASection } from '@/components/projects/project-cta-section'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
 import {
   Select,
   SelectContent,
@@ -109,7 +110,7 @@ export function ProjectsPageContent({ initialProjects }: ProjectsPageContentProp
           <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-4 mb-12">
             <div>
               <h2 className="font-display text-2xl lg:text-3xl font-semibold text-foreground mb-2">
-                Featured Work
+                All Case Studies
               </h2>
               <p className="text-muted-foreground">
                 Explore case studies in revenue operations and data analytics
@@ -143,7 +144,7 @@ export function ProjectsPageContent({ initialProjects }: ProjectsPageContentProp
                   <SelectItem value="all">All categories</SelectItem>
                   {categories.map((cat) => (
                     <SelectItem key={cat} value={cat}>
-                      {cat}
+                      {cat.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -167,6 +168,18 @@ export function ProjectsPageContent({ initialProjects }: ProjectsPageContentProp
                   ? 'Projects are currently being updated'
                   : 'Try adjusting your search or filters'}
               </p>
+              {initialProjects.length > 0 && (search || category !== 'all') && (
+                <Button
+                  variant="outline"
+                  className="mt-6"
+                  onClick={() => {
+                    setSearch(null)
+                    setCategory(null)
+                  }}
+                >
+                  Clear filters
+                </Button>
+              )}
             </div>
           ) : (
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">

--- a/src/app/projects/forecast-pipeline-intelligence/_components/ForecastPageContent.tsx
+++ b/src/app/projects/forecast-pipeline-intelligence/_components/ForecastPageContent.tsx
@@ -129,14 +129,8 @@ export default function ForecastPipelineIntelligenceProject() {
         {/* Key Metrics using standardized MetricsGrid */}
         <MetricsGrid metrics={metrics} columns={4} className="mb-8" />
 
-        {/* Intelligence Modules */}
-        <SectionCard
-          title="Intelligence Modules"
-          description="AI-powered forecasting and pipeline health monitoring capabilities"
-          className="mb-8"
-        >
-          <IntelligenceModulesGrid modules={intelligenceModules} />
-        </SectionCard>
+        {/* Intelligence Modules — IntelligenceModulesGrid renders its own titled SectionCard */}
+        <IntelligenceModulesGrid modules={intelligenceModules} />
 
         {/* Professional Narrative Sections - STAR Method */}
         <SectionCard

--- a/src/app/projects/partnership-program-implementation/_components/TechnicalDetails.tsx
+++ b/src/app/projects/partnership-program-implementation/_components/TechnicalDetails.tsx
@@ -28,17 +28,10 @@ const technicalDetails = [
 ]
 
 export function TechnicalDetails() {
+  // Heading comes from the wrapping <SectionCard title="Technical Implementation"> in
+  // PartnershipProgramPageContent — no inner <h2> here (avoids a duplicate, #117).
   return (
     <div className="space-y-12 mb-16">
-      <div className="text-center space-y-4">
-        <h2 className="font-display text-2xl md:text-3xl font-semibold text-foreground">
-          Technical Implementation
-        </h2>
-        <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
-          Production-ready systems and integrations built from the ground up
-        </p>
-      </div>
-
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
         {technicalDetails.map((detail, index) => (
           <div

--- a/src/app/projects/revenue-operations-center/_components/OperationsTab.tsx
+++ b/src/app/projects/revenue-operations-center/_components/OperationsTab.tsx
@@ -11,7 +11,10 @@ export function OperationsTab() {
           key={index}
           className="glass rounded-2xl p-8 hover:bg-white/[0.07] transition-all duration-300 ease-out"
         >
-          <h3 className="typography-h4 mb-6">{dept.department} Operations</h3>
+          {/* Avoid "Operations Operations" when the department is itself "Operations" */}
+          <h3 className="typography-h4 mb-6">
+            {dept.department === 'Operations' ? 'Operations' : `${dept.department} Operations`}
+          </h3>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
             {dept.metrics.map((metric, metricIndex) => (
               <div key={metricIndex} className="bg-white/5 rounded-xl p-4 border border-white/10">

--- a/src/app/projects/sales-enablement/_components/SalesEnablementPageContent.tsx
+++ b/src/app/projects/sales-enablement/_components/SalesEnablementPageContent.tsx
@@ -121,14 +121,8 @@ export default function SalesEnablementProject() {
         {/* Key Metrics using standardized MetricsGrid */}
         <MetricsGrid metrics={metrics} columns={4} className="mb-8" />
 
-        {/* Implementation Pillars */}
-        <SectionCard
-          title="Implementation Pillars"
-          description="Core program components driving sales performance transformation"
-          className="mb-8"
-        >
-          <PillarsGrid pillars={keyPillars} />
-        </SectionCard>
+        {/* Implementation Pillars — PillarsGrid renders its own titled SectionCard */}
+        <PillarsGrid pillars={keyPillars} />
 
         {/* Professional Narrative Sections - STAR Method */}
         <SectionCard


### PR DESCRIPTION
**#117** — remove duplicate section headings (each page wrapped a *self-titled* component in a same-titled `SectionCard`):
- forecast → drop outer 'Intelligence Modules' wrapper
- sales-enablement → drop outer 'Implementation Pillars' wrapper
- partnership → drop inner `<h2>` in TechnicalDetails (keep the SectionCard title)
- revenue-operations-center → 'Operations Operations' guarded (dept literally named 'Operations')

**#126** — projects index: add a **Clear filters** button to the no-results empty state (resets search + category); Title-Case the category dropdown labels (were raw slugs). The filter was already internally consistent (options derived from + filtered on `project.category`).

**#132** — index heading 'Featured Work' → **'All Case Studies'** (it lists all projects; 'Featured Work' is correctly the *curated* set on the homepage).

Also: **#111 closed as not-warranted** (alternate slugs aren't linked anywhere / not in sitemap / GSC 404=0 — speculative redirects), and **#133 closed** (tab state already persists via URL `useQueryState`).

typecheck + biome + build clean; full suite passing.

Closes #117
Closes #126
Closes #132