### PR TITLE
fix(a11y): global Navbar on project detail pages + aria-pressed selector (#122,#135)

### DIFF
--- a/src/components/projects/project-page-layout.tsx
+++ b/src/components/projects/project-page-layout.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { BackButton } from '@/components/navigation/back-button'
 import { NavigationBreadcrumbs } from '@/components/navigation/navigation-breadcrumbs'
+import { Navbar } from '@/components/layout/navbar'
 import type { ProjectPageLayoutProps } from '@/types/design-system'
 import { designTokens } from '@/lib/tokens'
 
@@ -45,6 +46,12 @@ export const ProjectPageLayout = React.forwardRef<HTMLDivElement, ProjectPageLay
         className={cn('relative min-h-screen bg-background overflow-hidden', className)}
         {...props}
       >
+        {/* Global site nav — these hardcoded project pages otherwise had only a
+            "Back to Projects" link (the dynamic [slug] route renders Navbar via
+            project-detail-client-boundary). The pt-24 content offset below already
+            clears the fixed h-16 navbar. */}
+        <Navbar />
+
         {/* Decorative background elements */}
         <div className="absolute top-1/4 -right-32 w-64 h-64 bg-primary/5 rounded-full blur-3xl" />
         <div className="absolute bottom-1/3 -left-32 w-64 h-64 bg-secondary/5 rounded-full blur-3xl" />
@@ -92,6 +99,7 @@ export const ProjectPageLayout = React.forwardRef<HTMLDivElement, ProjectPageLay
                       key={timeframe}
                       variant={activeTimeframe === timeframe ? 'default' : 'ghost'}
                       size="sm"
+                      aria-pressed={activeTimeframe === timeframe}
                       onClick={() => onTimeframeChange?.(timeframe)}
                       className={cn(
                         'px-4 py-2 rounded-lg text-sm font-medium',


### PR DESCRIPTION
**#122** — the hardcoded project pages render via `ProjectPageLayout`, which had only a 'Back to Projects' link and **no global `<Navbar>`** (confirmed live), trapping users. Added `<Navbar>` to `ProjectPageLayout` — one edit fixes all pages that use it. The existing `pt-24` offset clears the fixed bar; the dynamic `/projects/[slug]` route already has Navbar (via a different component), so no double nav.

**#135** — added `aria-pressed` to the timeframe-selector buttons (announces selected state). Other audited sub-items were already resolved: close-button has `aria-label`; the low-contrast 'ghost' KPI cards were replaced with clean MetricCards in #114.

Also closed **#130** as not-reproducible — the mobile menu is `absolute` under the `fixed` full-width navbar root, so it spans the full viewport (not the 'narrow column' the stale audit claimed).

typecheck + biome + build clean; full suite passing.

Closes #122
Closes #135