### PR TITLE
fix: resolve remaining UI/UX + codebase audit findings

### DIFF
--- a/drizzle/seed.ts
+++ b/drizzle/seed.ts
@@ -208,6 +208,18 @@ const SAMPLE_TAGS = [
     description: 'Customer cohort analysis techniques',
     color: '#F97316',
   },
+  {
+    name: 'Attribution Modeling',
+    slug: 'attribution-modeling',
+    description: 'Multi-touch and marketing attribution models',
+    color: '#EC4899',
+  },
+  {
+    name: 'Marketing Analytics',
+    slug: 'marketing-analytics',
+    description: 'Campaign measurement and marketing ROI analysis',
+    color: '#0EA5E9',
+  },
 ]
 
 // =======================
@@ -729,7 +741,9 @@ async function seedBlogPosts(
         'ROI analysis',
         'campaign measurement',
       ],
-      tagSlugs: ['ab-testing', 'forecasting', 'dashboards'],
+      // Tags describe the post's subject (marketing attribution), not unrelated
+      // topics. Previously mis-tagged ab-testing/forecasting/dashboards (#125).
+      tagSlugs: ['attribution-modeling', 'marketing-analytics', 'kpis'],
     },
     {
       title: 'Salesforce Revenue Analytics Implementation',

--- a/e2e/security-headers.spec.ts
+++ b/e2e/security-headers.spec.ts
@@ -133,20 +133,27 @@ test.describe('Security Headers', () => {
       expect(response.status()).toBe(403)
     })
 
-    test('POST /api/blog/tags without CSRF token returns 403', async ({ request }) => {
+    // /api/blog/tags and /api/blog/categories are gated by an admin Bearer token
+    // (Authorization header) BEFORE the CSRF check runs. A cross-origin CSRF
+    // attacker cannot set a custom Authorization header nor know ADMIN_API_TOKEN,
+    // so an unauthenticated POST is genuinely unauthorized: the route correctly
+    // returns 401 (auth) before it would return 403 (CSRF). This precedence is
+    // pinned in the route unit tests. The standalone CSRF-403 contract is covered
+    // by the /api/contact tests above, which have no admin gate.
+    test('POST /api/blog/tags without admin token returns 401 (auth precedes CSRF)', async ({ request }) => {
       const response = await request.post('/api/blog/tags', {
         data: { name: 'Test Tag' },
         headers: { 'Content-Type': 'application/json' },
       })
-      expect(response.status()).toBe(403)
+      expect(response.status()).toBe(401)
     })
 
-    test('POST /api/blog/categories without CSRF token returns 403', async ({ request }) => {
+    test('POST /api/blog/categories without admin token returns 401 (auth precedes CSRF)', async ({ request }) => {
       const response = await request.post('/api/blog/categories', {
         data: { name: 'Test Category' },
         headers: { 'Content-Type': 'application/json' },
       })
-      expect(response.status()).toBe(403)
+      expect(response.status()).toBe(401)
     })
 
     test('CSRF rejection response contains expected error message', async ({ request }) => {

--- a/scripts/fix-attribution-post-tags.ts
+++ b/scripts/fix-attribution-post-tags.ts
@@ -1,0 +1,95 @@
+/**
+ * Fix #125 — re-tag the Multi-Touch Attribution post.
+ *
+ * The post under the "Marketing Attribution" category was tagged
+ * A/B Testing / Forecasting / Dashboards — none describe its subject. This
+ * relinks it to attribution-relevant tags (creating the two new ones if the
+ * production DB doesn't have them yet), matching the corrected drizzle/seed.ts.
+ *
+ * Idempotent: running again is a no-op once the tags are correct.
+ * Safe by default — prints the plan and changes nothing unless APPLY=1.
+ *
+ *   bun run scripts/fix-attribution-post-tags.ts          # dry run (preview)
+ *   APPLY=1 bun run scripts/fix-attribution-post-tags.ts  # commit changes
+ */
+import { and, eq, inArray } from 'drizzle-orm'
+import { blogPosts, postTags, tags } from '../src/db/schema'
+import { createId } from '../src/db/cuid'
+import { createScriptDb } from './_db'
+
+const db = createScriptDb({ blogPosts, postTags, tags })
+
+const POST_SLUG = 'multi-touch-attribution-modeling-best-practices'
+
+// Desired final tag set. The two attribution tags are created if absent; `kpis`
+// already exists in the catalog (covers the ROI/metrics angle).
+const DESIRED_TAGS = [
+  { name: 'Attribution Modeling', slug: 'attribution-modeling', description: 'Multi-touch and marketing attribution models', color: '#EC4899' },
+  { name: 'Marketing Analytics', slug: 'marketing-analytics', description: 'Campaign measurement and marketing ROI analysis', color: '#0EA5E9' },
+  { name: 'KPIs', slug: 'kpis', description: 'Key Performance Indicators and metrics', color: '#3B82F6' },
+]
+
+const APPLY = process.env.APPLY === '1'
+
+async function main() {
+  const post = (
+    await db.select({ id: blogPosts.id, title: blogPosts.title }).from(blogPosts).where(eq(blogPosts.slug, POST_SLUG))
+  )[0]
+  if (!post) {
+    throw new Error(`Post not found: ${POST_SLUG}`)
+  }
+  console.log(`Post: ${post.title} (${post.id})`)
+
+  // Resolve / create each desired tag.
+  const desiredIds: string[] = []
+  for (const t of DESIRED_TAGS) {
+    let row = (await db.select({ id: tags.id }).from(tags).where(eq(tags.slug, t.slug)))[0]
+    if (!row) {
+      console.log(`  tag "${t.slug}" missing — ${APPLY ? 'creating' : 'would create'}`)
+      if (APPLY) {
+        row = (
+          await db
+            .insert(tags)
+            .values({ id: createId(), name: t.name, slug: t.slug, description: t.description, color: t.color })
+            .returning({ id: tags.id })
+        )[0]
+      }
+    }
+    if (row) desiredIds.push(row.id)
+  }
+
+  const current = await db
+    .select({ tagId: postTags.tagId, slug: tags.slug })
+    .from(postTags)
+    .innerJoin(tags, eq(postTags.tagId, tags.id))
+    .where(eq(postTags.postId, post.id))
+  console.log(`  current tags: ${JSON.stringify(current.map((c) => c.slug))}`)
+
+  const currentIds = new Set(current.map((c) => c.tagId))
+  const desiredSet = new Set(desiredIds)
+  const toAdd = desiredIds.filter((id) => !currentIds.has(id))
+  const toRemove = [...currentIds].filter((id) => !desiredSet.has(id))
+
+  console.log(`  desired tags: ${JSON.stringify(DESIRED_TAGS.map((t) => t.slug))}`)
+  console.log(`  +add ${toAdd.length}  -remove ${toRemove.length}`)
+
+  if (!APPLY) {
+    console.log('\nDRY RUN — re-run with APPLY=1 to commit.')
+    return
+  }
+
+  if (toRemove.length > 0) {
+    await db.delete(postTags).where(and(eq(postTags.postId, post.id), inArray(postTags.tagId, toRemove)))
+  }
+  if (toAdd.length > 0) {
+    await db.insert(postTags).values(toAdd.map((tagId) => ({ postId: post.id, tagId }))).onConflictDoNothing()
+  }
+  console.log('Applied. Re-running this script is a no-op.')
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })

--- a/scripts/fix-truncated-blog-meta.ts
+++ b/scripts/fix-truncated-blog-meta.ts
@@ -1,0 +1,107 @@
+/**
+ * Fix #119 — repair the truncated <title> and preview text on the
+ * "Stop Guessing… by 34% in One Quarter" post.
+ *
+ * The stored metaTitle and excerpt/metaDescription were cut mid-word
+ * ("…by 34% in O", "…relying on hard data. T"). This rewrites them to clean,
+ * word-boundary values derived from the post's own title + content:
+ *   - metaTitle      := the full post title (complete; search engines truncate
+ *                       the *display*, but the tag itself must not end mid-word)
+ *   - excerpt        := first ~155 chars of the content, cut on a word boundary
+ *   - metaDescription:= same clean summary (column is varchar(160))
+ *
+ * Idempotent: the derived values are deterministic, so re-running is a no-op.
+ * Safe by default — prints before/after and changes nothing unless APPLY=1.
+ *
+ *   bun run scripts/fix-truncated-blog-meta.ts          # dry run (preview)
+ *   APPLY=1 bun run scripts/fix-truncated-blog-meta.ts  # commit changes
+ */
+import { eq } from 'drizzle-orm'
+import { blogPosts } from '../src/db/schema'
+import { createScriptDb } from './_db'
+
+const db = createScriptDb({ blogPosts })
+
+const POST_SLUG = 'stop-guessing-how-we-crushed-forecasting-errors-by-34-in-one-quarter'
+const MAX_DESC = 157 // leave room for the ellipsis within varchar(160)
+const APPLY = process.env.APPLY === '1'
+
+/** Strip markdown/HTML to plain prose for a clean preview snippet. */
+function toPlainText(md: string): string {
+  return md
+    .replace(/```[\s\S]*?```/g, ' ') // fenced code
+    .replace(/`[^`]*`/g, ' ') // inline code
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ') // images
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1') // links → text
+    .replace(/^#{1,6}\s+/gm, '') // headings
+    .replace(/[*_>#~]/g, '') // emphasis / blockquote markers
+    .replace(/\s+/g, ' ') // collapse whitespace
+    .trim()
+}
+
+/** Truncate on a word boundary, appending an ellipsis only if cut. */
+function wordBoundarySummary(text: string, max: number): string {
+  if (text.length <= max) return text
+  const slice = text.slice(0, max)
+  const lastSpace = slice.lastIndexOf(' ')
+  const base = (lastSpace > 0 ? slice.slice(0, lastSpace) : slice).replace(/[\s.,;:!-]+$/, '')
+  return `${base}…`
+}
+
+async function main() {
+  const post = (
+    await db
+      .select({
+        id: blogPosts.id,
+        title: blogPosts.title,
+        metaTitle: blogPosts.metaTitle,
+        metaDescription: blogPosts.metaDescription,
+        excerpt: blogPosts.excerpt,
+        content: blogPosts.content,
+      })
+      .from(blogPosts)
+      .where(eq(blogPosts.slug, POST_SLUG))
+  )[0]
+  if (!post) {
+    throw new Error(`Post not found: ${POST_SLUG}`)
+  }
+
+  const cleanMetaTitle = post.title.trim()
+  const summary = wordBoundarySummary(toPlainText(post.content), MAX_DESC)
+
+  const show = (label: string, v: string | null) =>
+    console.log(`  ${label.padEnd(16)} (${(v ?? '').length}) ${JSON.stringify(v)}`)
+
+  console.log('BEFORE')
+  show('metaTitle', post.metaTitle)
+  show('excerpt', post.excerpt)
+  show('metaDescription', post.metaDescription)
+  console.log('AFTER')
+  show('metaTitle', cleanMetaTitle)
+  show('excerpt', summary)
+  show('metaDescription', summary)
+
+  const unchanged =
+    post.metaTitle === cleanMetaTitle && post.excerpt === summary && post.metaDescription === summary
+  if (unchanged) {
+    console.log('\nAlready clean — no-op.')
+    return
+  }
+  if (!APPLY) {
+    console.log('\nDRY RUN — re-run with APPLY=1 to commit.')
+    return
+  }
+
+  await db
+    .update(blogPosts)
+    .set({ metaTitle: cleanMetaTitle, excerpt: summary, metaDescription: summary })
+    .where(eq(blogPosts.id, post.id))
+  console.log('\nApplied. Re-running this script is a no-op.')
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })

--- a/scripts/inspect-audit-posts.ts
+++ b/scripts/inspect-audit-posts.ts
@@ -1,0 +1,96 @@
+/**
+ * READ-ONLY inspection for audit findings #119 and #125.
+ *
+ * Prints the current production state of:
+ *   - all `stop-guessing-*` posts (which are published vs soft-deleted) and
+ *     the truncated metaTitle/excerpt/metaDescription for the #119 post
+ *   - the Multi-Touch Attribution post's current tags (#125)
+ *
+ * Mutates nothing. Run: `bun run scripts/inspect-audit-posts.ts`
+ */
+import { eq, like } from 'drizzle-orm'
+import { blogPosts, postTags, tags } from '../src/db/schema'
+import { createScriptDb } from './_db'
+
+const db = createScriptDb({ blogPosts, postTags, tags })
+
+const TRUNC_SLUG = 'stop-guessing-how-we-crushed-forecasting-errors-by-34-in-one-quarter'
+const ATTR_SLUG = 'multi-touch-attribution-modeling-best-practices'
+
+function show(label: string, value: unknown) {
+  const s = value == null ? '∅' : String(value)
+  console.log(`  ${label.padEnd(18)} (${s.length}) ${JSON.stringify(s)}`)
+}
+
+async function main() {
+  console.log('\n=== #119: stop-guessing-* posts ===')
+  const sg = await db
+    .select({
+      slug: blogPosts.slug,
+      status: blogPosts.status,
+      deletedAt: blogPosts.deletedAt,
+      title: blogPosts.title,
+      metaTitle: blogPosts.metaTitle,
+      metaDescription: blogPosts.metaDescription,
+      excerpt: blogPosts.excerpt,
+      contentLen: blogPosts.content,
+    })
+    .from(blogPosts)
+    .where(like(blogPosts.slug, 'stop-guessing-%'))
+
+  for (const p of sg) {
+    const isTarget = p.slug === TRUNC_SLUG
+    console.log(
+      `\n${isTarget ? '>>> ' : '    '}${p.slug}  [${p.status}${p.deletedAt ? ' DELETED' : ''}]`
+    )
+    if (isTarget) {
+      show('title', p.title)
+      show('metaTitle', p.metaTitle)
+      show('metaDescription', p.metaDescription)
+      show('excerpt', p.excerpt)
+      const content = (p.contentLen as unknown as string) ?? ''
+      console.log(`  content len: ${content.length}`)
+      console.log(`  content head: ${JSON.stringify(content.slice(0, 320))}`)
+    }
+  }
+  if (!sg.some((p) => p.slug === TRUNC_SLUG)) {
+    console.log(`\n!!! target slug not found: ${TRUNC_SLUG}`)
+  }
+
+  console.log('\n=== #125: Multi-Touch Attribution post tags ===')
+  const post = await db
+    .select({ id: blogPosts.id, slug: blogPosts.slug, title: blogPosts.title })
+    .from(blogPosts)
+    .where(eq(blogPosts.slug, ATTR_SLUG))
+  if (post.length === 0) {
+    console.log(`!!! attribution post not found: ${ATTR_SLUG}`)
+  } else {
+    const target = post[0]!
+    console.log(`  post: ${target.title} (${target.id})`)
+    const linked = await db
+      .select({ tagName: tags.name, tagSlug: tags.slug })
+      .from(postTags)
+      .innerJoin(tags, eq(postTags.tagId, tags.id))
+      .where(eq(postTags.postId, target.id))
+    console.log(`  current tags: ${JSON.stringify(linked)}`)
+  }
+
+  console.log('\n=== available attribution-relevant tags in DB ===')
+  const candidate = await db
+    .select({ name: tags.name, slug: tags.slug })
+    .from(tags)
+    .where(like(tags.slug, '%attribution%'))
+  console.log(`  attribution-* tags: ${JSON.stringify(candidate)}`)
+  const marketing = await db
+    .select({ name: tags.name, slug: tags.slug })
+    .from(tags)
+    .where(like(tags.slug, '%marketing%'))
+  console.log(`  marketing-* tags: ${JSON.stringify(marketing)}`)
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -12,12 +12,13 @@ import { ArrowRight, Mail } from 'lucide-react'
 import Link from 'next/link'
 import type { Metadata } from 'next'
 import { canonicalUrl, SITE_ORIGIN } from '@/lib/absolute-url'
+import { REVENUE_IMPACT, TRANSACTION_GROWTH, NETWORK_GROWTH, YEARS_EXPERIENCE } from '@/lib/stats'
 
 const EXPERIENCE_STATS = [
-  { label: 'Projects Delivered', value: '10+', icon: 'check-circle' },
-  { label: 'Revenue Generated', value: '$4.8M+', icon: 'dollar-sign' },
-  { label: 'Transaction Growth', value: '432%', icon: 'bar-chart' },
-  { label: 'Network Expansion', value: '2,217%', icon: 'rocket' },
+  { label: 'Projects Delivered', value: YEARS_EXPERIENCE, icon: 'check-circle' },
+  { label: 'Revenue Generated', value: REVENUE_IMPACT, icon: 'dollar-sign' },
+  { label: 'Transaction Growth', value: TRANSACTION_GROWTH, icon: 'bar-chart' },
+  { label: 'Network Expansion', value: NETWORK_GROWTH, icon: 'rocket' },
 ]
 
 const CERTIFICATIONS = [

--- a/src/app/blog/_components/blog-list.tsx
+++ b/src/app/blog/_components/blog-list.tsx
@@ -8,6 +8,7 @@ import { InlineMarkdown } from './inline-markdown'
 import { BlogFeaturedImage } from '@/components/blog/blog-featured-image'
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { formatDate } from '@/lib/data-formatters'
 
 interface BlogListProps {
   initialPosts: BlogPostData[]
@@ -51,13 +52,9 @@ export function BlogList({ initialPosts, initialCategories }: BlogListProps) {
     return matchesCategory && matchesSearch
   })
 
-  function formatDate(dateString: string | undefined): string {
+  function formatPublishedDate(dateString: string | undefined): string {
     if (!dateString) return ''
-    return new Date(dateString).toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    })
+    return formatDate(dateString, { month: 'long' })
   }
 
   return (
@@ -134,7 +131,7 @@ export function BlogList({ initialPosts, initialCategories }: BlogListProps) {
                 </CardHeader>
                 <CardContent>
                   <time className="typography-small text-muted-foreground">
-                    {formatDate(post.publishedAt)}
+                    {formatPublishedDate(post.publishedAt)}
                   </time>
                 </CardContent>
               </Card>
@@ -144,6 +141,16 @@ export function BlogList({ initialPosts, initialCategories }: BlogListProps) {
       ) : (
         <div className="py-16 text-center">
           <p className="typography-muted">No posts found matching your filters.</p>
+          <button
+            type="button"
+            onClick={() => {
+              setSearchQuery(null)
+              setSelectedCategory(null)
+            }}
+            className="mt-4 inline-flex items-center px-4 py-2 rounded-lg border border-border bg-background text-sm font-medium text-foreground transition-colors hover:bg-muted focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+          >
+            Clear search
+          </button>
         </div>
       )}
     </div>

--- a/src/app/blog/_components/blog-post-layout.tsx
+++ b/src/app/blog/_components/blog-post-layout.tsx
@@ -1,10 +1,10 @@
 import Link from 'next/link'
-import { format } from 'date-fns'
 import { BlogFeaturedImage } from '@/components/blog/blog-featured-image'
 import { ArrowLeft, CalendarDays, Clock, Eye } from 'lucide-react'
 import type { BlogPostData } from '@/types/api'
 import { BlogPostArticle } from './blog-post-article'
 import { InlineMarkdown } from './inline-markdown'
+import { formatDate } from '@/lib/data-formatters'
 type ContentType = 'MARKDOWN' | 'HTML' | 'RICH_TEXT'
 import { Badge } from '@/components/ui/badge'
 import { Card } from '@/components/ui/card'
@@ -24,7 +24,7 @@ function getAuthorInitials(name: string): string {
 }
 
 export function BlogPostLayout({ post }: PostLayoutProps) {
-  const publishedDate = post.publishedAt ? format(new Date(post.publishedAt), 'MMMM d, yyyy') : null
+  const publishedDate = post.publishedAt ? formatDate(post.publishedAt, { month: 'long' }) : null
   const wordCount = post.wordCount ?? post.content.split(/\s+/).filter(Boolean).length
   const readingTime = post.readingTime ?? Math.max(1, Math.ceil(wordCount / 200))
   const authorName = post.author?.name ?? 'Richard Hudson'

--- a/src/app/blog/category/[slug]/page.tsx
+++ b/src/app/blog/category/[slug]/page.tsx
@@ -14,6 +14,7 @@ import { db } from '@/lib/db'
 import { blogPosts, categories } from '@/db/schema'
 import { createContextLogger } from '@/lib/logger'
 import { canonicalUrl, SITE_ORIGIN } from '@/lib/absolute-url'
+import { formatDate } from '@/lib/data-formatters'
 
 // Force runtime rendering — see /blog/[slug]/page.tsx for the rationale.
 // notFound() inside ISR-rendered Server Components ships HTTP 200 with a
@@ -123,13 +124,9 @@ export async function generateMetadata({ params }: BlogCategoryPageProps): Promi
   }
 }
 
-function formatDate(value: Date | null): string {
+function formatPublishedDate(value: Date | null): string {
   if (!value) return ''
-  return new Date(value).toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  })
+  return formatDate(value, { month: 'long' })
 }
 
 export default async function BlogCategoryPage({ params }: BlogCategoryPageProps) {
@@ -233,7 +230,7 @@ export default async function BlogCategoryPage({ params }: BlogCategoryPageProps
                         </CardHeader>
                         <CardContent>
                           <time className="text-sm text-muted-foreground">
-                            {formatDate(post.publishedAt)}
+                            {formatPublishedDate(post.publishedAt)}
                           </time>
                         </CardContent>
                       </Card>

--- a/src/app/contact/contact-client.tsx
+++ b/src/app/contact/contact-client.tsx
@@ -5,6 +5,8 @@ import { Navbar } from '@/components/layout/navbar'
 import { ContactForm } from '@/components/contact/contact-form'
 import { ContactInfo } from '@/components/contact/contact-info'
 import { FeaturedProjects } from '@/components/contact/featured-projects'
+import { AvailabilityBadge } from '@/components/ui/availability-badge'
+import { REVENUE_IMPACT } from '@/lib/stats'
 import { useContactForm } from '@/hooks/use-contact-form'
 
 // ============================================================================
@@ -27,6 +29,7 @@ export default function ContactPageClient() {
           <div className="relative max-w-7xl mx-auto px-6 lg:px-8">
             {/* Header */}
             <div className="text-center mb-12">
+              <AvailabilityBadge className="mx-auto mb-6" />
               <h1 className="font-display text-3xl md:text-4xl lg:text-5xl font-bold text-foreground mb-6">
                 Let's <span className="text-primary">Connect</span>
               </h1>
@@ -51,7 +54,7 @@ export default function ContactPageClient() {
                 </div>
                 <div className="flex items-center gap-2">
                   <CheckCircle className="w-4 h-4 text-primary" />
-                  <span>$4.8M+ Revenue Impact</span>
+                  <span>{REVENUE_IMPACT} Revenue Impact</span>
                 </div>
               </div>
             </div>

--- a/src/app/resume/_components/HeroHeader.tsx
+++ b/src/app/resume/_components/HeroHeader.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { FileDown, Mail, Globe, Eye } from 'lucide-react'
 import { Github, Linkedin } from '@/components/ui/brand-icons'
+import { AvailabilityBadge } from '@/components/ui/availability-badge'
 
 interface HeroHeaderProps {
   showPdf: boolean
@@ -25,6 +26,7 @@ export function HeroHeader({
   // a 2-6s flash because IntersectionObserver hadn't fired yet).
   return (
     <div className="text-center space-y-8 max-w-4xl mx-auto animate-fade-in-up">
+      <AvailabilityBadge className="mx-auto" />
       <h1 className="text-4xl sm:text-5xl md:text-5xl lg:text-6xl font-bold tracking-tight mb-8">
         <span className="block hero-name-gradient">Richard Hudson</span>
       </h1>
@@ -71,12 +73,15 @@ export function HeroHeader({
                 </Button>
               </div>
 
-              {/* View Toggle - Interactive */}
-              <div className="group relative overflow-hidden rounded-xl bg-secondary/10 border border-secondary/30 hover:border-secondary/50 transition-all duration-300 hover:scale-105">
+              {/* View Toggle - Interactive (ghost/outline so it reads as a
+                  secondary control, visually distinct from the primary
+                  Download PDF action) */}
+              <div className="group relative overflow-hidden rounded-xl bg-transparent border border-dashed border-border hover:border-secondary/50 hover:bg-secondary/5 transition-all duration-300">
                 <Button
                   size="lg"
-                  className="relative w-full h-20 bg-transparent hover:bg-secondary/5 text-foreground border-0 shadow-none p-6"
+                  className="relative w-full h-20 bg-transparent hover:bg-transparent text-muted-foreground border-0 shadow-none p-6"
                   onClick={onToggleView}
+                  aria-pressed={showPdf}
                 >
                   <div className="flex flex-col items-center justify-center space-y-1">
                     <Eye
@@ -84,7 +89,7 @@ export function HeroHeader({
                       className="text-secondary group-hover:scale-110 transition-all duration-300 ease-out"
                     />
                     <span className="text-sm font-medium">
-                      {showPdf ? 'Interactive View' : 'PDF View'}
+                      {showPdf ? 'Hide preview' : 'Preview PDF'}
                     </span>
                   </div>
                 </Button>

--- a/src/components/about/personal-info.tsx
+++ b/src/components/about/personal-info.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Mail, MapPin, Eye, Briefcase } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
+import { AvailabilityBadge } from '@/components/ui/availability-badge'
 
 interface PersonalInfo {
   name: string
@@ -25,6 +26,7 @@ export function PersonalInfo({ personalInfo, className = '' }: PersonalInfoProps
       <div className="grid lg:grid-cols-2 gap-12 items-center">
         <div className="space-y-8">
           <div>
+            <AvailabilityBadge className="mb-6" />
             <h1 className="font-display text-3xl md:text-4xl lg:text-5xl font-bold mb-4 text-foreground">
               {personalInfo.name}
             </h1>

--- a/src/components/contact/__tests__/contact-form.test.tsx
+++ b/src/components/contact/__tests__/contact-form.test.tsx
@@ -119,6 +119,16 @@ describe('ContactForm', () => {
     expect((btn as HTMLButtonElement).disabled).toBe(false)
   })
 
+  it('shows helper text explaining the disabled submit when terms not agreed', () => {
+    renderForm({ agreedToTerms: false })
+    expect(screen.getByText(/accept the privacy policy to send your message/i)).toBeTruthy()
+  })
+
+  it('hides the disabled-submit helper text once terms are agreed', () => {
+    renderForm({ agreedToTerms: true })
+    expect(screen.queryByText(/accept the privacy policy to send your message/i)).toBeNull()
+  })
+
   it('disables submit button while submitting even with terms agreed', () => {
     renderForm({ agreedToTerms: true, isSubmitting: true })
     // The accessible name changes to the loading state

--- a/src/components/contact/contact-form.tsx
+++ b/src/components/contact/contact-form.tsx
@@ -255,6 +255,16 @@ export function ContactForm({ form: formHook }: ContactFormProps) {
           )}
         </button>
 
+        {/* Explain why the submit button is disabled until terms are accepted */}
+        {!agreedToTerms && (
+          <p
+            aria-live="polite"
+            className="typography-small text-muted-foreground text-center -mt-2"
+          >
+            Please accept the privacy policy to send your message.
+          </p>
+        )}
+
         {/* Status Messages */}
         {submitStatus === 'success' && (
           <div

--- a/src/components/contact/success-stories.tsx
+++ b/src/components/contact/success-stories.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { CheckCircle } from 'lucide-react'
+import { REVENUE_IMPACT, TRANSACTION_GROWTH, NETWORK_GROWTH } from '@/lib/stats'
 
 // ============================================================================
 // Component
@@ -13,15 +14,15 @@ export function SuccessStories() {
       <div className="space-y-3 text-sm">
         <div className="flex items-center gap-2">
           <CheckCircle className="w-4 h-4 text-success" />
-          <span>$4.8M+ revenue generated</span>
+          <span>{REVENUE_IMPACT} revenue generated</span>
         </div>
         <div className="flex items-center gap-2">
           <CheckCircle className="w-4 h-4 text-success" />
-          <span>432% transaction growth</span>
+          <span>{TRANSACTION_GROWTH} transaction growth</span>
         </div>
         <div className="flex items-center gap-2">
           <CheckCircle className="w-4 h-4 text-success" />
-          <span>2,217% network expansion</span>
+          <span>{NETWORK_GROWTH} network expansion</span>
         </div>
       </div>
       <div className="mt-4 typography-small text-muted-foreground">

--- a/src/components/layout/__tests__/navbar.test.tsx
+++ b/src/components/layout/__tests__/navbar.test.tsx
@@ -9,6 +9,24 @@ vi.mock('next/navigation', () => ({
 
 import { Navbar } from '../navbar'
 
+describe('Navbar — CTA hidden on /contact', () => {
+  beforeEach(() => {
+    cleanup()
+    vi.resetModules()
+  })
+
+  it('does not render the "Let\'s Talk" CTA on the /contact page', async () => {
+    vi.doMock('next/navigation', () => ({ usePathname: () => '/contact' }))
+    const { Navbar: ContactNavbar } = await import('../navbar')
+    const { container } = render(<ContactNavbar />)
+    const ctas = Array.from(
+      container.querySelectorAll<HTMLAnchorElement>('a[href="/contact"]')
+    ).filter((a) => a.textContent?.toLowerCase().includes("let's talk"))
+    expect(ctas.length).toBe(0)
+    vi.doUnmock('next/navigation')
+  })
+})
+
 describe('Navbar', () => {
   beforeEach(() => {
     cleanup()

--- a/src/components/layout/home-page-content.tsx
+++ b/src/components/layout/home-page-content.tsx
@@ -15,6 +15,17 @@ import {
 import { Navbar } from '@/components/layout/navbar'
 import { NumberTicker } from '@/components/ui/number-ticker'
 import { Button } from '@/components/ui/button'
+import { AvailabilityBadge } from '@/components/ui/availability-badge'
+import {
+  REVENUE_IMPACT,
+  TRANSACTION_GROWTH,
+  NETWORK_GROWTH,
+  YEARS_EXPERIENCE,
+  REVENUE_IMPACT_VALUE,
+  TRANSACTION_GROWTH_VALUE,
+  NETWORK_GROWTH_VALUE,
+  YEARS_EXPERIENCE_VALUE,
+} from '@/lib/stats'
 
 // Animated counter with visual impact
 function ImpactMetric({
@@ -109,10 +120,7 @@ export default function HomePageContent() {
              */}
             <div className="space-y-8">
               {/* Eyebrow */}
-              <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 text-primary text-sm font-medium">
-                <span className="w-2 h-2 rounded-full bg-secondary animate-pulse" />
-                Available for opportunities
-              </div>
+              <AvailabilityBadge />
 
               {/* Main Headline */}
               <div className="space-y-4">
@@ -203,25 +211,25 @@ export default function HomePageContent() {
                   {/* Quick stats */}
                   <div className="grid grid-cols-2 gap-4">
                     <div className="bg-muted/50 rounded-xl p-4 text-center">
-                      <div className="text-2xl font-bold text-primary">$4.8M+</div>
+                      <div className="text-2xl font-bold text-primary">{REVENUE_IMPACT}</div>
                       <div className="text-xs text-muted-foreground uppercase tracking-wide mt-1">
                         Revenue Impact
                       </div>
                     </div>
                     <div className="bg-muted/50 rounded-xl p-4 text-center">
-                      <div className="text-2xl font-bold text-secondary">432%</div>
+                      <div className="text-2xl font-bold text-secondary">{TRANSACTION_GROWTH}</div>
                       <div className="text-xs text-muted-foreground uppercase tracking-wide mt-1">
                         Growth Delivered
                       </div>
                     </div>
                     <div className="bg-muted/50 rounded-xl p-4 text-center">
-                      <div className="text-2xl font-bold text-accent">2,217%</div>
+                      <div className="text-2xl font-bold text-accent">{NETWORK_GROWTH}</div>
                       <div className="text-xs text-muted-foreground uppercase tracking-wide mt-1">
                         Network Growth
                       </div>
                     </div>
                     <div className="bg-muted/50 rounded-xl p-4 text-center">
-                      <div className="text-2xl font-bold text-foreground">10+</div>
+                      <div className="text-2xl font-bold text-foreground">{YEARS_EXPERIENCE}</div>
                       <div className="text-xs text-muted-foreground uppercase tracking-wide mt-1">
                         Years Experience
                       </div>
@@ -254,7 +262,7 @@ export default function HomePageContent() {
           {/* Metrics grid */}
           <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8 lg:gap-12">
             <ImpactMetric
-              value={4.8}
+              value={REVENUE_IMPACT_VALUE}
               prefix="$"
               suffix="M+"
               label="Revenue Generated"
@@ -263,20 +271,26 @@ export default function HomePageContent() {
               decimalPlaces={1}
             />
             <ImpactMetric
-              value={432}
+              value={TRANSACTION_GROWTH_VALUE}
               suffix="%"
               label="Growth Achieved"
               icon={TrendingUp}
               delay={0.1}
             />
             <ImpactMetric
-              value={2217}
+              value={NETWORK_GROWTH_VALUE}
               suffix="%"
               label="Network Expansion"
               icon={Users}
               delay={0.2}
             />
-            <ImpactMetric value={10} suffix="+" label="Years Experience" icon={Clock} delay={0.3} />
+            <ImpactMetric
+              value={YEARS_EXPERIENCE_VALUE}
+              suffix="+"
+              label="Years Experience"
+              icon={Clock}
+              delay={0.3}
+            />
           </div>
         </div>
       </section>
@@ -421,10 +435,10 @@ export default function HomePageContent() {
           <div className="text-center">
             <Link
               href="/projects"
-              className="inline-flex items-center gap-2 text-primary hover:underline font-medium"
+              className="group inline-flex items-center gap-2 text-primary hover:underline font-medium"
             >
               View all projects
-              <ArrowRight className="w-4 h-4" />
+              <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
             </Link>
           </div>
         </div>

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -66,14 +66,16 @@ export function Navbar() {
             </button>
           </div>
 
-          {/* Desktop CTA button */}
+          {/* Desktop CTA button — hidden on /contact (already there) */}
           <div className="hidden md:flex items-center w-32 justify-end">
-            <Link
-              href="/contact"
-              className="bg-primary text-primary-foreground text-sm font-medium px-4 py-2 rounded-lg transition-all duration-300 ease-out shadow-sm hover:bg-primary/95 hover:shadow-md"
-            >
-              Let's Talk
-            </Link>
+            {pathname !== '/contact' && (
+              <Link
+                href="/contact"
+                className="bg-primary text-primary-foreground text-sm font-medium px-4 py-2 rounded-lg transition-all duration-300 ease-out shadow-sm hover:bg-primary/95 hover:shadow-md"
+              >
+                Let's Talk
+              </Link>
+            )}
           </div>
         </div>
 
@@ -102,13 +104,15 @@ export function Navbar() {
                 {item.title}
               </Link>
             ))}
-            <Link
-              href="/contact"
-              onClick={() => setIsMobileMenuOpen(false)}
-              className="w-full bg-primary text-primary-foreground text-base font-medium px-4 py-3 rounded-lg transition-all duration-300 ease-out shadow-sm hover:bg-primary/95 min-h-[44px] flex items-center justify-center"
-            >
-              Let's Talk
-            </Link>
+            {pathname !== '/contact' && (
+              <Link
+                href="/contact"
+                onClick={() => setIsMobileMenuOpen(false)}
+                className="w-full bg-primary text-primary-foreground text-base font-medium px-4 py-3 rounded-lg transition-all duration-300 ease-out shadow-sm hover:bg-primary/95 min-h-[44px] flex items-center justify-center"
+              >
+                Let's Talk
+              </Link>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/projects/project-cta-section.tsx
+++ b/src/components/projects/project-cta-section.tsx
@@ -3,6 +3,7 @@
 import type React from 'react'
 import Link from 'next/link'
 import { ArrowRight, FileText, Lightbulb, MessageSquare } from 'lucide-react'
+import { REVENUE_IMPACT, TRANSACTION_GROWTH } from '@/lib/stats'
 
 interface ProjectCTASectionProps {
   totalProjects: number
@@ -90,14 +91,14 @@ export const ProjectCTASection: React.FC<ProjectCTASectionProps> = ({ totalProje
         <div className="flex flex-wrap justify-center gap-8 lg:gap-16 text-center">
           <div>
             <div className="font-mono text-3xl lg:text-4xl font-bold text-foreground mb-1">
-              $4.8M+
+              {REVENUE_IMPACT}
             </div>
             <div className="text-sm text-muted-foreground">Revenue Impact</div>
           </div>
           <div className="hidden sm:block w-px bg-border" />
           <div>
             <div className="font-mono text-3xl lg:text-4xl font-bold text-foreground mb-1">
-              432%
+              {TRANSACTION_GROWTH}
             </div>
             <div className="text-sm text-muted-foreground">Average Growth</div>
           </div>

--- a/src/components/projects/project-stats.tsx
+++ b/src/components/projects/project-stats.tsx
@@ -2,6 +2,7 @@
 
 import type React from 'react'
 import { TrendingUp, BarChart3, Target, Zap } from 'lucide-react'
+import { REVENUE_IMPACT, TRANSACTION_GROWTH, NETWORK_GROWTH } from '@/lib/stats'
 
 interface ProjectStatsProps {
   totalProjects: number
@@ -11,21 +12,22 @@ interface ProjectStatsProps {
 const stats = [
   {
     icon: TrendingUp,
-    value: '$4.8M+',
+    value: REVENUE_IMPACT,
     label: 'Revenue Optimized',
   },
   {
     icon: BarChart3,
-    value: '432%',
+    value: TRANSACTION_GROWTH,
     label: 'Average Growth',
   },
   {
     icon: Target,
-    value: '2,217%',
+    value: NETWORK_GROWTH,
     label: 'Network Expansion',
   },
   {
     icon: Zap,
+    // Placeholder; overridden at render with the live project count.
     value: '11+',
     label: 'Case Studies',
   },

--- a/src/components/ui/availability-badge.tsx
+++ b/src/components/ui/availability-badge.tsx
@@ -1,0 +1,33 @@
+import { cn } from '@/lib/utils'
+
+interface AvailabilityBadgeProps {
+  /** Optional wrapper classes for per-surface spacing/centering. */
+  className?: string
+  /** Badge label. Defaults to the canonical availability copy. */
+  label?: string
+}
+
+/**
+ * Shared "Available for opportunities" status pill.
+ *
+ * Single source of truth for the green availability badge that appears in the
+ * hero of the home, about, resume, and contact pages. Markup mirrors the
+ * original homepage pill (inline-flex rounded-full bg-primary/10 with a pulsing
+ * bg-secondary dot) so the visual is identical across every surface.
+ */
+export function AvailabilityBadge({
+  className,
+  label = 'Available for opportunities',
+}: AvailabilityBadgeProps) {
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 text-primary text-sm font-medium',
+        className
+      )}
+    >
+      <span className="w-2 h-2 rounded-full bg-secondary animate-pulse" />
+      {label}
+    </div>
+  )
+}

--- a/src/lib/__tests__/csrf-protection.test.ts
+++ b/src/lib/__tests__/csrf-protection.test.ts
@@ -137,13 +137,25 @@ describe('setCSRFTokenCookie', () => {
 })
 
 describe('csrfProtectionMiddleware', () => {
-  it('returns { valid: true, token } for GET requests and sets cookie', async () => {
+  it('returns { valid: true, token } for GET requests and sets cookie when absent', async () => {
+    mockCookieStore.get.mockReturnValue(undefined)
     const request = new Request('http://test.example', { method: 'GET' })
     const result = await csrfProtectionMiddleware(request)
 
     expect(result.valid).toBe(true)
     expect(result.token).toMatch(/^[0-9a-f]{64}$/)
     expect(mockCookieStore.set).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT rotate the cookie on GET when a token already exists', async () => {
+    const existing = generateCSRFToken()
+    mockCookieStore.get.mockReturnValue({ value: existing })
+    const request = new Request('http://test.example', { method: 'GET' })
+    const result = await csrfProtectionMiddleware(request)
+
+    expect(result.valid).toBe(true)
+    expect(result.token).toBe(existing)
+    expect(mockCookieStore.set).not.toHaveBeenCalled()
   })
 
   it('returns { valid: true } for POST with valid x-csrf-token header', async () => {
@@ -185,6 +197,37 @@ describe('csrfProtectionMiddleware', () => {
     const result = await csrfProtectionMiddleware(request)
     expect(result.valid).toBe(false)
     expect(result.error).toContain('header')
+  })
+
+  it('rejects an oversized form-data POST without parsing the body', async () => {
+    mockCookieStore.get.mockReturnValue({ value: generateCSRFToken() })
+    const request = new Request('http://test.example', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'content-length': String(64 * 1024 + 1),
+      },
+    })
+    const formDataSpy = vi.spyOn(request, 'clone')
+
+    const result = await csrfProtectionMiddleware(request)
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('too large')
+    // Guard must short-circuit before we ever clone/parse the body.
+    expect(formDataSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects a form-data POST with a missing Content-Length', async () => {
+    mockCookieStore.get.mockReturnValue({ value: generateCSRFToken() })
+    const request = new Request('http://test.example', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: '_csrf_token=anything',
+    })
+
+    const result = await csrfProtectionMiddleware(request)
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('too large')
   })
 
   it('returns { valid: true } for PUT with valid x-csrf-token header', async () => {

--- a/src/lib/__tests__/data-formatters.test.ts
+++ b/src/lib/__tests__/data-formatters.test.ts
@@ -105,6 +105,12 @@ describe('formatDate', () => {
     expect(formatDate(new Date('2026-05-09T00:00:00Z'))).toMatch(/May/)
   })
 
+  it('matches blog long-month rendering (date-fns parity)', () => {
+    expect(formatDate(new Date('2026-09-03T12:00:00Z'), { month: 'long' })).toBe(
+      'September 3, 2026'
+    )
+  })
+
   it('accepts string input', () => {
     expect(formatDate('2026-05-09T00:00:00Z')).toMatch(/2026/)
   })

--- a/src/lib/__tests__/search.test.ts
+++ b/src/lib/__tests__/search.test.ts
@@ -16,10 +16,22 @@ vi.mock('@/lib/db', () => ({
   db: { execute: executeMock },
 }))
 
-import { searchBlogPosts, highlightSearchTerms, getSearchSuggestions } from '@/lib/search'
+import {
+  searchBlogPosts,
+  highlightSearchTerms,
+  getSearchSuggestions,
+  __resetPgTrgmCache,
+} from '@/lib/search'
+
+// Probe result rows for the pg_trgm capability check (hasPgTrgm): a non-empty
+// array means the extension is present (trigram path), [] means absent (ILIKE
+// fallback path).
+const TRGM_PRESENT = [{ '?column?': 1 }]
+const TRGM_ABSENT: unknown[] = []
 
 beforeEach(() => {
   executeMock.mockReset()
+  __resetPgTrgmCache()
 })
 
 describe('searchBlogPosts', () => {
@@ -52,24 +64,65 @@ describe('searchBlogPosts', () => {
     expect(executeMock).toHaveBeenCalledTimes(1) // skipped fuzzy
   })
 
-  it('falls back to fuzzy when full-text yields too few hits', async () => {
+  it('falls back to fuzzy (trigram) when full-text yields too few hits', async () => {
     const ftRows = [
       { id: '1', title: 't', slug: 's', excerpt: null, rank: 0.9, matchType: 'exact' as const },
     ]
     const fzRows = [
       { id: '2', title: 'fuzzy', slug: 'f', excerpt: null, rank: 0.4, matchType: 'fuzzy' as const },
     ]
-    executeMock.mockResolvedValueOnce(ftRows).mockResolvedValueOnce(fzRows)
+    // ft query → pg_trgm probe (present) → trigram fuzzy query
+    executeMock
+      .mockResolvedValueOnce(ftRows)
+      .mockResolvedValueOnce(TRGM_PRESENT)
+      .mockResolvedValueOnce(fzRows)
     const result = await searchBlogPosts('react')
     expect(result).toHaveLength(2)
-    expect(executeMock).toHaveBeenCalledTimes(2)
+    expect(executeMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('falls back to ILIKE fuzzy search when pg_trgm is unavailable', async () => {
+    const ftRows = [
+      { id: '1', title: 't', slug: 's', excerpt: null, rank: 0.9, matchType: 'exact' as const },
+    ]
+    const fzRows = [
+      { id: '2', title: 'fuzzy', slug: 'f', excerpt: null, rank: 0.6, matchType: 'fuzzy' as const },
+    ]
+    // ft query → pg_trgm probe (ABSENT) → ILIKE fuzzy query
+    executeMock
+      .mockResolvedValueOnce(ftRows)
+      .mockResolvedValueOnce(TRGM_ABSENT)
+      .mockResolvedValueOnce(fzRows)
+    const result = await searchBlogPosts('react')
+    expect(result).toHaveLength(2)
+    expect(executeMock).toHaveBeenCalledTimes(3)
+    // The ILIKE branch must not reference the `%` similarity operator.
+    const fuzzySql = JSON.stringify(executeMock.mock.calls[2])
+    expect(fuzzySql).toContain('ILIKE')
+    expect(fuzzySql).not.toContain('similarity(')
+  })
+
+  it('caches the pg_trgm probe across calls (probes once)', async () => {
+    const ftRows = [
+      { id: '1', title: 't', slug: 's', excerpt: null, rank: 0.9, matchType: 'exact' as const },
+    ]
+    executeMock.mockResolvedValue(ftRows) // ft hits < 5 → always tries fuzzy
+    executeMock.mockResolvedValueOnce(ftRows).mockResolvedValueOnce(TRGM_PRESENT)
+    await searchBlogPosts('react') // ft + probe + fuzzy
+    const callsAfterFirst = executeMock.mock.calls.length
+    await searchBlogPosts('react') // ft + fuzzy (no second probe)
+    expect(executeMock.mock.calls.length).toBe(callsAfterFirst + 2)
   })
 
   it('returns full-text rows even if fuzzy fallback throws', async () => {
     const ftRows = [
       { id: '1', title: 't', slug: 's', excerpt: null, rank: 0.9, matchType: 'exact' as const },
     ]
-    executeMock.mockResolvedValueOnce(ftRows).mockRejectedValueOnce(new Error('db down'))
+    // ft query → pg_trgm probe (present) → fuzzy query rejects
+    executeMock
+      .mockResolvedValueOnce(ftRows)
+      .mockResolvedValueOnce(TRGM_PRESENT)
+      .mockRejectedValueOnce(new Error('db down'))
     const result = await searchBlogPosts('react')
     expect(result).toEqual(ftRows)
   })

--- a/src/lib/csrf-protection.ts
+++ b/src/lib/csrf-protection.ts
@@ -8,6 +8,12 @@ const logger = createContextLogger('CSRFProtection')
 const CSRF_TOKEN_LENGTH = 32
 const CSRF_TOKEN_NAME = '__csrf_token'
 const CSRF_HEADER_NAME = 'x-csrf-token'
+// Upper bound on a form-encoded body we are willing to buffer+parse purely to
+// extract the _csrf_token field. A CSRF form only needs the token plus a few
+// small fields, so 64KB is generous. Enforced via Content-Length BEFORE
+// request.formData() to avoid a DoS amplification vector where an attacker
+// forces full-body parsing on a request that has no token.
+const CSRF_MAX_FORM_BODY_BYTES = 64 * 1024
 
 /**
  * Generate a secure CSRF token
@@ -67,7 +73,14 @@ export async function csrfProtectionMiddleware(
 ): Promise<{ valid: boolean; token?: string; error?: string }> {
   // Only validate on state-changing requests
   if (!allowedMethods.includes(request.method.toUpperCase())) {
-    // Generate a new token for GET requests
+    // Issue a token for safe (e.g. GET) requests, but do NOT rotate an existing
+    // one: regenerating the cookie on every GET would invalidate the token held
+    // by any in-flight form (e.g. one opened in another tab). Only mint+set a
+    // new token when the cookie is absent.
+    const existingToken = await getCSRFTokenFromCookie()
+    if (existingToken) {
+      return { valid: true, token: existingToken }
+    }
     const token = generateCSRFToken()
     await setCSRFTokenCookie(token)
     return { valid: true, token }
@@ -92,6 +105,21 @@ export async function csrfProtectionMiddleware(
         contentType.includes('application/x-www-form-urlencoded') ||
         contentType.includes('multipart/form-data')
       ) {
+        // Enforce a size guard BEFORE parsing the body. Parsing first would let
+        // an attacker force full-body buffering on a tokenless request (DoS
+        // amplification). A missing or unparseable Content-Length is rejected
+        // too, so a chunked body can't slip past the check.
+        const contentLength = request.headers.get('content-length')
+        if (
+          contentLength === null ||
+          !Number.isFinite(Number(contentLength)) ||
+          Number(contentLength) > CSRF_MAX_FORM_BODY_BYTES
+        ) {
+          return {
+            valid: false,
+            error: 'Request body too large for CSRF token extraction',
+          }
+        }
         // For form data, we need to clone the request to read it without consuming the body elsewhere
         const clonedRequest = request.clone()
         const formData = await clonedRequest.formData()

--- a/src/lib/rate-limiter/store.ts
+++ b/src/lib/rate-limiter/store.ts
@@ -350,8 +350,11 @@ export class RateLimiter implements Disposable {
       .map((record) => record.requestHistory.filter((t) => t > now - 60000).length)
       .reduce((sum, count) => sum + count, 0)
 
-    // Normalize to 0-1 scale based on reasonable thresholds
-    const maxExpectedClients = 1000
+    // Normalize to 0-1 scale based on the store's real capacity. Tie the
+    // client-load denominator to the eviction target (the steady-state ceiling
+    // LRU eviction drives the store toward) so the signal reaches 1.0 exactly
+    // as eviction begins reclaiming — not at an arbitrary 10% of capacity.
+    const maxExpectedClients = Math.floor(MAX_STORE_SIZE * EVICTION_TARGET_RATIO)
     const maxExpectedRPM = 10000 // requests per minute
 
     const clientLoad = Math.min(totalActiveClients / maxExpectedClients, 1)

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -22,6 +22,33 @@ export interface SearchResult {
   matchType: 'exact' | 'fuzzy'
 }
 
+/**
+ * The fuzzy fallback uses the `%` similarity operator, which only exists when
+ * the `pg_trgm` extension is installed. Probe for it once per process and
+ * cache the result so a missing extension degrades to an `ILIKE` substring
+ * fallback instead of throwing (and silently returning only the full-text
+ * hits via the outer catch). `null` = not yet probed.
+ */
+let pgTrgmAvailable: boolean | null = null
+
+export async function hasPgTrgm(): Promise<boolean> {
+  if (pgTrgmAvailable !== null) {
+    return pgTrgmAvailable
+  }
+  try {
+    const rows = await db.execute(sql`SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm' LIMIT 1`)
+    pgTrgmAvailable = (rows as unknown as unknown[]).length > 0
+  } catch {
+    pgTrgmAvailable = false
+  }
+  return pgTrgmAvailable
+}
+
+/** Test-only hook to reset the cached `pg_trgm` probe between cases. */
+export function __resetPgTrgmCache(): void {
+  pgTrgmAvailable = null
+}
+
 export async function searchBlogPosts(
   query: string,
   options: {
@@ -83,26 +110,54 @@ export async function searchBlogPosts(
           )})`
         : sql``
 
-    const fzRows = await db.execute(sql`
-      SELECT
-        id,
-        title,
-        slug,
-        excerpt,
-        GREATEST(
-          similarity(title, ${query}),
-          similarity(COALESCE(excerpt, ''), ${query})
-        ) as rank,
-        'fuzzy' as "matchType"
-      FROM blog_posts
-      WHERE (title % ${query} OR COALESCE(excerpt, '') % ${query})
-        ${statusCondition}
-        ${exclusion}
-      ORDER BY rank DESC
-      LIMIT ${Math.max(0, limit - fullTextResults.length)}
-      OFFSET ${offset}
-    `)
-    const fuzzyResults = fzRows as unknown as SearchResult[]
+    const fuzzyLimit = Math.max(0, limit - fullTextResults.length)
+
+    let fuzzyRows: unknown
+    if (await hasPgTrgm()) {
+      // Trigram similarity ranking (typo-tolerant). Requires pg_trgm.
+      fuzzyRows = await db.execute(sql`
+        SELECT
+          id,
+          title,
+          slug,
+          excerpt,
+          GREATEST(
+            similarity(title, ${query}),
+            similarity(COALESCE(excerpt, ''), ${query})
+          ) as rank,
+          'fuzzy' as "matchType"
+        FROM blog_posts
+        WHERE (title % ${query} OR COALESCE(excerpt, '') % ${query})
+          ${statusCondition}
+          ${exclusion}
+        ORDER BY rank DESC
+        LIMIT ${fuzzyLimit}
+        OFFSET ${offset}
+      `)
+    } else {
+      // pg_trgm absent — fall back to a case-insensitive substring match so
+      // search still degrades gracefully instead of returning only the
+      // full-text hits. LIKE wildcards in the user's query are escaped so
+      // they're treated literally. Title matches rank above excerpt matches.
+      const likePattern = `%${query.replace(/[\\%_]/g, '\\$&')}%`
+      fuzzyRows = await db.execute(sql`
+        SELECT
+          id,
+          title,
+          slug,
+          excerpt,
+          CASE WHEN title ILIKE ${likePattern} THEN 0.6 ELSE 0.3 END as rank,
+          'fuzzy' as "matchType"
+        FROM blog_posts
+        WHERE (title ILIKE ${likePattern} OR COALESCE(excerpt, '') ILIKE ${likePattern})
+          ${statusCondition}
+          ${exclusion}
+        ORDER BY rank DESC, title ASC
+        LIMIT ${fuzzyLimit}
+        OFFSET ${offset}
+      `)
+    }
+    const fuzzyResults = fuzzyRows as unknown as SearchResult[]
 
     return [...fullTextResults, ...fuzzyResults]
   } catch (error) {

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -1,0 +1,38 @@
+/**
+ * Canonical headline statistics — single source of truth.
+ *
+ * These figures appear across the home, about, resume, contact, and projects
+ * surfaces. Previously they were duplicated as hardcoded literals in ~7 files;
+ * import from here instead so a number only ever changes in one place.
+ *
+ * Two shapes are exported for each metric:
+ *   - the display string (e.g. '$4.8M+') for static text
+ *   - the raw numeric value (e.g. 4.8) for animated counters such as the
+ *     homepage NumberTicker, which formats the prefix/suffix itself.
+ *
+ * Per-surface labels intentionally differ ('Revenue Optimized' vs
+ * 'Revenue Generated' vs 'Revenue Impact'); only the values are canonical.
+ */
+
+/** Display strings. */
+export const REVENUE_IMPACT = '$4.8M+'
+export const TRANSACTION_GROWTH = '432%'
+export const NETWORK_GROWTH = '2,217%'
+export const YEARS_EXPERIENCE = '10+'
+
+/** Raw numeric values for animated counters (NumberTicker formats prefix/suffix). */
+export const REVENUE_IMPACT_VALUE = 4.8
+export const TRANSACTION_GROWTH_VALUE = 432
+export const NETWORK_GROWTH_VALUE = 2217
+export const YEARS_EXPERIENCE_VALUE = 10
+
+/**
+ * Labeled list for table-style consumers that want a default label alongside
+ * each value. Consumers may override `label` for their surface.
+ */
+export const HEADLINE_STATS = [
+  { key: 'revenue', value: REVENUE_IMPACT, label: 'Revenue Impact' },
+  { key: 'growth', value: TRANSACTION_GROWTH, label: 'Transaction Growth' },
+  { key: 'network', value: NETWORK_GROWTH, label: 'Network Expansion' },
+  { key: 'experience', value: YEARS_EXPERIENCE, label: 'Years Experience' },
+] as const


### PR DESCRIPTION
Final batch of the audit backlog — every remaining open finding from the UI/UX report and the dead-code/bugs report, fixed, integrated, and verified. No stubs, no TODOs, no deferrals.

## UI/UX
- **#121** Resume PDF toggle now reads as a *secondary* control (dashed/ghost border, muted text, `aria-pressed`, "Preview PDF" / "Hide preview") so it's visually distinct from the primary Download PDF action.
- **#127** Contact form surfaces an `aria-live` helper explaining the submit button is disabled until the privacy policy is accepted.
- **#139** "Let's Talk" nav CTA is hidden on `/contact` (desktop + mobile) — no link to the page you're already on.
- **#140** Blog empty state gains a **Clear search** reset button.
- **#141** "View all projects" arrow CTA gets the standard `group-hover:translate-x-1` hover treatment.
- **#142** Every blog date routes through `formatDate` (date-fns parity) instead of ad-hoc `toLocaleDateString`; local helpers renamed to avoid shadowing the import.
- **#143** Shared `AvailabilityBadge` pill extracted to one component, used on home / about / resume / contact (previously duplicated inline markup).

## Single source of truth
- **#110** New `src/lib/stats.ts` — headline figures (`$4.8M+`, `432%`, `2,217%`, `10+`) now imported across home / about / contact / projects instead of being re-typed as literals in ~7 files.

## Security / correctness
- **#103** CSRF middleware no longer rotates the cookie on safe (GET) requests when a token already exists — it only mints when the cookie is absent, so a form opened in another tab keeps its valid token.
- **#104** A 64 KB `Content-Length` ceiling is enforced **before** parsing form bodies for CSRF extraction. A missing or unparseable `Content-Length` is also rejected, so a chunked body can't slip past the guard or force full-body buffering on a tokenless request (DoS amplification). *(Caught and corrected during adversarial review: `Number(null) === 0` would otherwise have let a header-less request through.)*
- **#185** Rate-limiter global-load denominator now derives from the store's real capacity (`MAX_STORE_SIZE * EVICTION_TARGET_RATIO`) instead of a hardcoded `1000`, so the load signal reaches 1.0 exactly as LRU eviction begins.
- **#169** `search.ts` fuzzy fallback no longer assumes `pg_trgm`. It probes the extension once (cached) and degrades to a case-insensitive `ILIKE` substring match when absent, instead of throwing and silently returning only the full-text hits. LIKE wildcards in the user query are escaped. +3 unit tests.

## Content (seed + prod scripts)
- **#125** The Multi-Touch Attribution post was tagged `ab-testing`/`forecasting`/`dashboards` — none describe the subject. `drizzle/seed.ts` now defines two catalog tags (Attribution Modeling, Marketing Analytics) and re-tags the post `attribution-modeling`/`marketing-analytics`/`kpis`.
- **#119** No code-level truncation exists — the mid-word `<title>`/preview came from truncated stored values on a prod-authored post.

## Tests
- **#102** Not a code bug — corrected the e2e expectations. `/api/blog/{tags,categories}` are admin-Bearer gated, so auth (**401**) precedes CSRF (**403**); the standalone CSRF-403 contract is covered by the `/api/contact` tests (no admin gate). Pinned with an explanatory comment.
- New unit coverage for #103 non-rotation and #104 size-guard short-circuit.

## ⚠️ Production data follow-ups (not auto-closed)
**#119** and **#125** have a production-data component that this PR cannot apply from CI — the live blog content lives in the Neon prod DB (the local `.env` `DATABASE_URL` points at a now-dead Neon endpoint, HTTP 404). Two committed, idempotent, dry-run-by-default scripts apply the live fix once a valid `DATABASE_URL` is present:
- `scripts/fix-attribution-post-tags.ts` (#125 — re-tags the live row, creating the two new tags if absent)
- `scripts/fix-truncated-blog-meta.ts` (#119 — rewrites metaTitle/excerpt/metaDescription to clean, word-boundary values)
- `scripts/inspect-audit-posts.ts` (read-only diagnostic)

Run `bun run scripts/<name>.ts` to preview, then `APPLY=1 bun run scripts/<name>.ts` to commit. #119 and #125 stay **open** until these run against prod.

## Verification
- `bun run typecheck` ✓
- `bunx biome check src` ✓
- `bunx vitest run` — 1038 passed / 94 files ✓
- `bun run build` ✓

Closes #102
Closes #103
Closes #104
Closes #110
Closes #121
Closes #127
Closes #139
Closes #140
Closes #141
Closes #142
Closes #143
Closes #169
Closes #185

[hudsor01]