### PR TITLE
fix(scripts): correct audit prod-fix scripts to match what was applied (#119, #125)

### DIFF
--- a/scripts/fix-attribution-post-tags.ts
+++ b/scripts/fix-attribution-post-tags.ts
@@ -47,10 +47,22 @@ async function main() {
     if (!row) {
       console.log(`  tag "${t.slug}" missing — ${APPLY ? 'creating' : 'would create'}`)
       if (APPLY) {
+        // The prod `tags` table was created by Prisma: `updatedAt` (@updatedAt)
+        // has NO database default, so Drizzle's implicit DEFAULT violates the
+        // NOT NULL constraint. Set both timestamps explicitly.
+        const now = new Date()
         row = (
           await db
             .insert(tags)
-            .values({ id: createId(), name: t.name, slug: t.slug, description: t.description, color: t.color })
+            .values({
+              id: createId(),
+              name: t.name,
+              slug: t.slug,
+              description: t.description,
+              color: t.color,
+              createdAt: now,
+              updatedAt: now,
+            })
             .returning({ id: tags.id })
         )[0]
       }

--- a/scripts/fix-truncated-blog-meta.ts
+++ b/scripts/fix-truncated-blog-meta.ts
@@ -1,34 +1,38 @@
 /**
- * Fix #119 — repair the truncated <title> and preview text on the
- * "Stop Guessing… by 34% in One Quarter" post.
+ * Fix #119 — repair mid-word-truncated metaTitle / excerpt / metaDescription
+ * across all live blog posts.
  *
- * The stored metaTitle and excerpt/metaDescription were cut mid-word
- * ("…by 34% in O", "…relying on hard data. T"). This rewrites them to clean,
- * word-boundary values derived from the post's own title + content:
- *   - metaTitle      := the full post title (complete; search engines truncate
- *                       the *display*, but the tag itself must not end mid-word)
- *   - excerpt        := first ~155 chars of the content, cut on a word boundary
- *   - metaDescription:= same clean summary (column is varchar(160))
+ * The audit named one post ("…by 34% in One Quarter"), but that post is now
+ * soft-deleted (GSC consolidation). The underlying defect — a CMS that hard-cut
+ * metaTitle at 60 chars and excerpt/metaDescription mid-content — affects the
+ * surviving published posts too. This scans every PUBLISHED, non-deleted post
+ * and repairs only fields that are demonstrably auto-truncated:
  *
- * Idempotent: the derived values are deterministic, so re-running is a no-op.
- * Safe by default — prints before/after and changes nothing unless APPLY=1.
+ *   - metaTitle: fixed only when it is a strict *prefix* of the full title
+ *     (i.e. the title was cut). A genuinely custom metaTitle is left alone.
+ *   - excerpt / metaDescription: fixed only when the stored value is a prefix
+ *     slice of the post body (auto-generated), replaced with a clean
+ *     word-boundary summary. Hand-written copy that isn't a body slice is
+ *     left untouched.
  *
- *   bun run scripts/fix-truncated-blog-meta.ts          # dry run (preview)
- *   APPLY=1 bun run scripts/fix-truncated-blog-meta.ts  # commit changes
+ * Idempotent (derived values are deterministic). Dry-run by default.
+ *   bun run scripts/fix-truncated-blog-meta.ts          # preview
+ *   APPLY=1 bun run scripts/fix-truncated-blog-meta.ts  # commit
  */
-import { eq } from 'drizzle-orm'
+import { and, eq, isNull } from 'drizzle-orm'
 import { blogPosts } from '../src/db/schema'
 import { createScriptDb } from './_db'
 
 const db = createScriptDb({ blogPosts })
 
-const POST_SLUG = 'stop-guessing-how-we-crushed-forecasting-errors-by-34-in-one-quarter'
-const MAX_DESC = 157 // leave room for the ellipsis within varchar(160)
+const MAX_DESC = 157 // metaDescription is varchar(160); leave room for the ellipsis
+const MAX_EXCERPT = 300 // preserve the original on-page preview length
 const APPLY = process.env.APPLY === '1'
 
-/** Strip markdown/HTML to plain prose for a clean preview snippet. */
+/** Strip the leading H1 + markdown/HTML to plain prose. */
 function toPlainText(md: string): string {
   return md
+    .replace(/^\s*#\s+.*$/m, '') // leading H1 heading
     .replace(/```[\s\S]*?```/g, ' ') // fenced code
     .replace(/`[^`]*`/g, ' ') // inline code
     .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ') // images
@@ -48,55 +52,68 @@ function wordBoundarySummary(text: string, max: number): string {
   return `${base}…`
 }
 
+/**
+ * A stored excerpt/description is an auto-slice of the body if the body starts
+ * with it minus its trailing (possibly partial) word. Catches both clean and
+ * mid-word cuts while sparing genuinely-authored copy.
+ */
+function isBodySlice(field: string, plainBody: string): boolean {
+  const probe = field.replace(/[…\s]*\S*$/, '').trim() // drop trailing (partial) word / ellipsis
+  return probe.length >= 20 && plainBody.startsWith(probe) && field.trim() !== plainBody
+}
+
 async function main() {
-  const post = (
-    await db
-      .select({
-        id: blogPosts.id,
-        title: blogPosts.title,
-        metaTitle: blogPosts.metaTitle,
-        metaDescription: blogPosts.metaDescription,
-        excerpt: blogPosts.excerpt,
-        content: blogPosts.content,
-      })
-      .from(blogPosts)
-      .where(eq(blogPosts.slug, POST_SLUG))
-  )[0]
-  if (!post) {
-    throw new Error(`Post not found: ${POST_SLUG}`)
+  const posts = await db
+    .select({
+      id: blogPosts.id,
+      slug: blogPosts.slug,
+      title: blogPosts.title,
+      metaTitle: blogPosts.metaTitle,
+      metaDescription: blogPosts.metaDescription,
+      excerpt: blogPosts.excerpt,
+      content: blogPosts.content,
+    })
+    .from(blogPosts)
+    .where(and(eq(blogPosts.status, 'PUBLISHED'), isNull(blogPosts.deletedAt)))
+
+  console.log(`Scanning ${posts.length} published posts…\n`)
+
+  let changed = 0
+  for (const p of posts) {
+    const title = p.title.trim()
+    const plainBody = toPlainText(p.content)
+    const excerptSummary = wordBoundarySummary(plainBody, MAX_EXCERPT)
+    const descSummary = wordBoundarySummary(plainBody, MAX_DESC)
+
+    const set: { metaTitle?: string; excerpt?: string; metaDescription?: string } = {}
+
+    // metaTitle: only repair a prefix-truncation of the title.
+    if (p.metaTitle && p.metaTitle !== title && title.startsWith(p.metaTitle)) {
+      set.metaTitle = title
+    }
+    // excerpt: repair only auto-sliced bodies (preserve ~original length).
+    if (p.excerpt && p.excerpt !== excerptSummary && isBodySlice(p.excerpt, plainBody)) {
+      set.excerpt = excerptSummary
+    }
+    // metaDescription: repair only auto-sliced bodies (varchar(160)-safe).
+    if (p.metaDescription && p.metaDescription !== descSummary && isBodySlice(p.metaDescription, plainBody)) {
+      set.metaDescription = descSummary
+    }
+
+    if (Object.keys(set).length === 0) continue
+    changed++
+    console.log(`• ${p.slug}`)
+    if (set.metaTitle) console.log(`    metaTitle: ${JSON.stringify(p.metaTitle)} → ${JSON.stringify(set.metaTitle)}`)
+    if (set.excerpt) console.log(`    excerpt:   ${JSON.stringify(p.excerpt?.slice(-30))} → …${JSON.stringify(set.excerpt.slice(-30))}`)
+    if (set.metaDescription) console.log(`    metaDesc:  ${JSON.stringify(p.metaDescription?.slice(-30))} → …${JSON.stringify(set.metaDescription.slice(-30))}`)
+
+    if (APPLY) {
+      await db.update(blogPosts).set(set).where(eq(blogPosts.id, p.id))
+    }
   }
 
-  const cleanMetaTitle = post.title.trim()
-  const summary = wordBoundarySummary(toPlainText(post.content), MAX_DESC)
-
-  const show = (label: string, v: string | null) =>
-    console.log(`  ${label.padEnd(16)} (${(v ?? '').length}) ${JSON.stringify(v)}`)
-
-  console.log('BEFORE')
-  show('metaTitle', post.metaTitle)
-  show('excerpt', post.excerpt)
-  show('metaDescription', post.metaDescription)
-  console.log('AFTER')
-  show('metaTitle', cleanMetaTitle)
-  show('excerpt', summary)
-  show('metaDescription', summary)
-
-  const unchanged =
-    post.metaTitle === cleanMetaTitle && post.excerpt === summary && post.metaDescription === summary
-  if (unchanged) {
-    console.log('\nAlready clean — no-op.')
-    return
-  }
-  if (!APPLY) {
-    console.log('\nDRY RUN — re-run with APPLY=1 to commit.')
-    return
-  }
-
-  await db
-    .update(blogPosts)
-    .set({ metaTitle: cleanMetaTitle, excerpt: summary, metaDescription: summary })
-    .where(eq(blogPosts.id, post.id))
-  console.log('\nApplied. Re-running this script is a no-op.')
+  console.log(`\n${changed} post(s) ${APPLY ? 'updated' : 'need repair'}.`)
+  if (!APPLY && changed > 0) console.log('DRY RUN — re-run with APPLY=1 to commit.')
 }
 
 main()


### PR DESCRIPTION
Follow-up to #200. The #119/#125 prod-fix scripts were committed before being run against the live DB; running them (the local `.env` endpoint was dead, so this happened once a current `DATABASE_URL` was supplied) surfaced two corrections — **both already applied to production and verified**.

### `fix-attribution-post-tags.ts` (#125)
The prod `tags` table was created by Prisma, whose `@updatedAt` column has **no database default**. Drizzle's implicit `DEFAULT` violated the `NOT NULL` constraint on insert. Now sets `createdAt`/`updatedAt` explicitly.

**Result (verified):** the Multi-Touch Attribution post is now tagged `kpis` / `attribution-modeling` / `marketing-analytics`; re-run is `+0/-0`.

### `fix-truncated-blog-meta.ts` (#119)
The post named in the issue was already **soft-deleted** (GSC consolidation), so its truncated title no longer affects SEO — but the defect was **systemic**: a 60-char mid-word `metaTitle` cut and mid-content `excerpt`/`metaDescription` slices across **all 23 live posts**. Rewrote to scan every `PUBLISHED`, non-deleted post and repair only demonstrably auto-truncated fields:
- `metaTitle` fixed only when it is a strict prefix of the full title (custom metaTitles left alone) → full title
- `excerpt` / `metaDescription` fixed only when they are body slices → clean word-boundary summaries (`excerpt` ≤300, `metaDescription` ≤157)

**Result (verified):** 23 posts repaired; re-run reports `0 post(s) need repair`. Sample: `metaTitle(65) "Stop Guessing: How We Slashed Forecast Variance by 34% in 90 Days"`.

Both scripts are idempotent. No application/runtime code changes — `scripts/` only.

Closes #119
Closes #125

[hudsor01]