### PR TITLE
fix(csp): remove dead report-uri/report-to directives; document unsafe-inline tradeoff

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,7 +64,11 @@ Defensive controls currently in place:
 - HTTPS enforced — `NEXT_PUBLIC_SITE_URL` must be HTTPS in production
   (validated at boot in `src/lib/env-validation.ts`)
 - **HSTS**: `max-age=31536000; includeSubDomains; preload`
-- **CSP** with per-request nonces — `src/lib/csp-edge.ts`
+- **CSP** set per-request in `proxy.ts` (built by `src/lib/csp-edge.ts`):
+  `default-src 'self'`, `object-src 'self' blob:`, `base-uri 'self'`,
+  `form-action 'self'`, `frame-ancestors 'none'`, `upgrade-insecure-requests`.
+  `script-src`/`style-src` use `'unsafe-inline'` (not a nonce) — see the note
+  under [Known gaps](#known-gaps--follow-ups) for why.
 - `X-Frame-Options: DENY`
 - `X-Content-Type-Options: nosniff`
 - `Referrer-Policy: strict-origin-when-cross-origin`
@@ -129,6 +133,23 @@ These are publicly documented so reporters don't waste cycles on them:
   `/api/seed` and the blog mutation endpoints (POST/PUT/DELETE).
   `METRICS_API_TOKEN` is consumed by `/api/security/metrics`. There is no
   user-facing auth (no login, no sessions, no JWT).
+- **CSP `script-src` uses `'unsafe-inline'`** (accepted, bounded residual
+  risk). A per-request nonce is incompatible with this site's static
+  prerendering: Next.js 16 only injects a nonce when a route renders
+  dynamically, so adding one would force `/`, `/about`, `/projects`, `/resume`
+  off CDN static caching — and a nonce source in `script-src` makes browsers
+  ignore `'unsafe-inline'`, which would block Next's framework-generated inline
+  hydration scripts (`self.__next_f.push`) and break hydration on the
+  prerendered pages. `experimental.sri` (hash-based) does not cover those
+  dynamically-generated inline scripts either. The residual XSS surface is low:
+  no user-generated HTML is rendered, and inline JSON-LD is escaped via
+  `safeJsonLdStringify`. The rest of the policy (`object-src`, `base-uri`,
+  `form-action`, `frame-ancestors 'none'`, `upgrade-insecure-requests`) covers
+  clickjacking and injection-redirect vectors. CSP violation **reporting is
+  intentionally not configured** — a report sink with no triage workflow adds
+  an unauthenticated POST surface for no operational benefit on a static site.
+  Scanners that flag `'unsafe-inline'` as an ineffective CSP are reporting this
+  documented tradeoff, not a missing header (the header is present and enforced).
 
 ---
 

--- a/next.config.js
+++ b/next.config.js
@@ -68,7 +68,7 @@ const nextConfig = {
             // Explicitly disabled. The header is non-standard, removed from
             // Chrome/Edge/Firefox, and `1; mode=block` can enable reflected
             // XSS via response-splitting on legacy engines that still honor
-            // it. CSP (nonced, set in proxy.ts) is the real XSS control.
+            // it. CSP (set per-request in proxy.ts) is the real XSS control.
             // Refs: OWASP Secure Headers, MDN X-XSS-Protection.
             key: 'X-XSS-Protection',
             value: '0',
@@ -83,7 +83,9 @@ const nextConfig = {
             key: 'Permissions-Policy',
             value: 'camera=(), microphone=(), geolocation=(), browsing-topics=()',
           },
-          // CSP itself is set per-request in proxy.ts so the nonce can rotate.
+          // CSP itself is set per-request in proxy.ts (script-src uses
+          // 'unsafe-inline', not a nonce — see SECURITY.md for why a nonce is
+          // incompatible with this site's static prerendering).
         ],
       },
       {

--- a/src/lib/__tests__/csp-edge.test.ts
+++ b/src/lib/__tests__/csp-edge.test.ts
@@ -108,21 +108,15 @@ describe('buildEnhancedCSP', () => {
   })
 
   describe('reporting directives', () => {
-    it('omits report-uri / report-to when addReporting is false', () => {
-      const csp = buildEnhancedCSP({ addReporting: false })
+    // The CSP must NOT advertise report-uri / report-to: there is no
+    // /api/csp-report route and no Reporting-Endpoints/Report-To header
+    // declaring the group, so both directives were dead (the report endpoint
+    // 404s). Pin their absence so they can't be reintroduced without a live
+    // endpoint + reporting-group declaration.
+    it('never emits report-uri or report-to (no live report endpoint)', () => {
+      const csp = buildEnhancedCSP({ isDev: false, emitUpgradeInsecureRequests: true })
       expect(csp).not.toContain('report-uri')
       expect(csp).not.toContain('report-to')
-    })
-
-    it('emits report-uri and report-to when addReporting is true', () => {
-      const csp = buildEnhancedCSP({ addReporting: true })
-      expect(csp).toContain('report-uri /api/csp-report')
-      expect(csp).toContain('report-to csp-endpoint')
-    })
-
-    it('omits reporting by default (caller must opt in explicitly)', () => {
-      const csp = buildEnhancedCSP()
-      expect(csp).not.toContain('report-uri')
     })
   })
 })

--- a/src/lib/csp-edge.ts
+++ b/src/lib/csp-edge.ts
@@ -22,14 +22,6 @@ export interface BuildCSPOptions {
    * {@link shouldEmitUpgradeInsecureRequests} — never from a client header.
    */
   emitUpgradeInsecureRequests?: boolean
-  /**
-   * True when the response should include `report-uri` / `report-to`
-   * directives pointing at the project's CSP report endpoint. Caller-driven
-   * (rather than reading `process.env.NODE_ENV` inside the function) so a
-   * single call to `buildEnhancedCSP` always produces a coherent header
-   * regardless of how its caller derived the production signal.
-   */
-  addReporting?: boolean
 }
 
 /**
@@ -60,7 +52,7 @@ export function shouldEmitUpgradeInsecureRequests(
 }
 
 export function buildEnhancedCSP(options: BuildCSPOptions = {}): string {
-  const { isDev = false, emitUpgradeInsecureRequests = false, addReporting = false } = options
+  const { isDev = false, emitUpgradeInsecureRequests = false } = options
   const directives = [
     "default-src 'self'",
     `script-src 'self' 'unsafe-inline' https://vercel.live https://va.vercel-scripts.com https://vitals.vercel-insights.com${isDev ? " 'unsafe-eval'" : ''}`,
@@ -79,11 +71,6 @@ export function buildEnhancedCSP(options: BuildCSPOptions = {}): string {
   // Otherwise, defer to the caller-derived emit signal.
   if (!isDev && emitUpgradeInsecureRequests) {
     directives.push('upgrade-insecure-requests')
-  }
-
-  if (addReporting) {
-    directives.push('report-uri /api/csp-report')
-    directives.push('report-to csp-endpoint')
   }
 
   return directives.join('; ')

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -12,7 +12,6 @@ export function proxy(request: NextRequest) {
       process.env,
       request.nextUrl.protocol
     ),
-    addReporting: process.env.NODE_ENV === 'production',
   })
 
   // Pass nonce downstream for JSON-LD scripts in layout.tsx


### PR DESCRIPTION
Resolves the Aikido **"Content Security Policy (CSP) header not set"** finding (risk 91) on richardwhudsonjr.com / /about. Root-caused via a multi-agent investigation (codebase audit + live-header probing + cited Next.js 16 research).

## Verdict
- **The literal finding is a stale false positive.** The `Content-Security-Policy` header *is* present and enforced on every route — verified via `curl -sI` against production (`/`, `/about`, and dynamic routes). A re-scan in Aikido clears the "not set" verdict.
- **Real defect (fixed):** the prod CSP advertised two **dead** reporting directives:
  - `report-uri /api/csp-report` → that route **does not exist** (404s)
  - `report-to csp-endpoint` → reporting group **never declared** by any `Report-To`/`Reporting-Endpoints` header

  Shipping dead directives is the actual bug. Removed the `addReporting` option from `buildEnhancedCSP()` and its call site in `proxy.ts`. CSP violation reporting is **intentionally not configured** — a report sink with no triage workflow just adds an unauthenticated POST surface for a static portfolio.
- **`script-src 'unsafe-inline'` is kept** as a consciously-accepted, documented residual risk. A per-request nonce is incompatible with this site's **static prerendering**: Next.js 16 only injects nonces on dynamically-rendered routes, so adopting one would force `/`, `/about`, `/projects`, `/resume` off CDN static caching — and a nonce source in `script-src` makes browsers ignore `'unsafe-inline'`, which would break Next's framework inline hydration scripts (`self.__next_f.push`). `experimental.sri` (hashes) doesn't cover those dynamic inline scripts either. Residual XSS surface is low (no user-generated HTML; JSON-LD escaped via `safeJsonLdStringify`), and `object-src`/`base-uri`/`form-action`/`frame-ancestors 'none'`/`upgrade-insecure-requests` cover the rest.

## Changes
- `src/lib/csp-edge.ts` — drop the `addReporting` option + dead `report-uri`/`report-to` block
- `src/proxy.ts` — drop the `addReporting` argument
- `src/lib/__tests__/csp-edge.test.ts` — pin that the CSP **never** emits `report-uri`/`report-to`
- `next.config.js` — correct two comments that falsely claimed a rotating nonce
- `SECURITY.md` — correct "CSP with per-request nonces" → accurate description; document the `unsafe-inline` accepted tradeoff and why reporting is off

Left intentionally: the inert JSON-LD nonce plumbing (harmless; removing it is a separate render-mode-sensitive refactor).

## Verification
- `bun run typecheck` ✓ · `bunx biome check src` ✓ · `bunx vitest run` 1036 ✓ · `bun run build` ✓
- Built prod CSP string verified to no longer contain `report-uri`/`report-to`.
- After merge + deploy: re-scan Aikido to clear the stale "not set" verdict.

[hudsor01]