### PR TITLE
fix(csp): tighten img-src off the bare https: wildcard to the unsplash whitelist

### DIFF
--- a/src/lib/__tests__/csp-edge.test.ts
+++ b/src/lib/__tests__/csp-edge.test.ts
@@ -105,6 +105,14 @@ describe('buildEnhancedCSP', () => {
       const csp = buildEnhancedCSP()
       expect(csp).toContain("default-src 'self'")
     })
+
+    it('restricts img-src to the whitelisted host (no bare https: wildcard)', () => {
+      const csp = buildEnhancedCSP()
+      const imgSrc = csp.split(';').find((d) => d.trim().startsWith('img-src')) || ''
+      expect(imgSrc).toContain('https://images.unsplash.com')
+      // The bare `https:` scheme-source allowed images from ANY host — pin it gone.
+      expect(imgSrc).not.toMatch(/(^|\s)https:(\s|$)/)
+    })
   })
 
   describe('reporting directives', () => {

--- a/src/lib/csp-edge.ts
+++ b/src/lib/csp-edge.ts
@@ -57,7 +57,11 @@ export function buildEnhancedCSP(options: BuildCSPOptions = {}): string {
     "default-src 'self'",
     `script-src 'self' 'unsafe-inline' https://vercel.live https://va.vercel-scripts.com https://vitals.vercel-insights.com${isDev ? " 'unsafe-eval'" : ''}`,
     `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`,
-    "img-src 'self' data: blob: https: *.unsplash.com",
+    // Tightened off the bare `https:` wildcard (allowed images from any HTTPS
+    // host) to the single whitelisted remote host — matches next.config.js
+    // images.remotePatterns (images.unsplash.com only). 'self' covers /api/og
+    // + /public; data:/blob: cover Next placeholders + generated images.
+    "img-src 'self' data: blob: https://images.unsplash.com",
     "font-src 'self' https://fonts.gstatic.com",
     "connect-src 'self' https://vercel.live https://va.vercel-scripts.com https://vitals.vercel-insights.com",
     "frame-src 'self' blob:",


### PR DESCRIPTION
Resolves the Aikido **"CSP configuration is not restrictive enough"** finding (Medium) for richardwhudsonjr.com. Its subissue flagged `img-src` as overly broad: the policy was `img-src 'self' data: blob: https: *.unsplash.com` — the bare **`https:`** scheme-source allowed images from *any* HTTPS host.

## Change
`img-src 'self' data: blob: https://images.unsplash.com` — restricted to the single whitelisted remote host, matching `next.config.js` `images.remotePatterns` (images.unsplash.com only).

**Verified safe:**
- `next.config` allows only `images.unsplash.com` for `next/image` (it already rejects other hosts).
- Featured images are built as `https://images.unsplash.com/photo-...` via `src/lib/unsplash.ts`.
- No non-unsplash external image references exist in the repo.
- `'self'` covers `/api/og` + `/public`; `data:`/`blob:` cover Next placeholders + generated images.

> Assumption: blog content images are unsplash/self only (consistent with the documented whitelist). If any published post embeds an image from another host, it would be blocked — flag it and I'll whitelist that host.

## Why this one was *fixed*, not risk-accepted
This is a real hardening, distinct from the `script-src`/`style-src 'unsafe-inline'` findings — those are an accepted, documented tradeoff (a nonce is incompatible with static prerendering; see `SECURITY.md`) and were **risk-accepted in Aikido** with a rationale note. The `img-src` over-breadth had no such constraint, so it's genuinely fixable.

## Verification
- `bun run typecheck` ✓ · `bunx biome check src` ✓ · `bunx vitest run` 1037 ✓ (+1 regression pin) · `bun run build` ✓
- Built CSP verified: `img-src 'self' data: blob: https://images.unsplash.com` (no bare `https:`).
- Clears on the next Aikido scan after deploy.

[hudsor01]