### PR TITLE
seo: add internal-link footer for crawlability (attacks the 41 'Discovered – not indexed')

### DIFF
--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,10 +1,92 @@
+import Link from 'next/link'
+
+// Sitewide internal-link surface. Every page (including the handful Google has
+// actually indexed) renders this footer, so these links create crawl paths +
+// distribute what little authority the site has down into the category hubs
+// and cornerstone posts — directly targeting the "Discovered – currently not
+// indexed" backlog. Curated to GSC-confirmed-live URLs only (no 404 risk).
+const FOOTER_SECTIONS: ReadonlyArray<{
+  heading: string
+  links: ReadonlyArray<{ label: string; href: string }>
+}> = [
+  {
+    heading: 'Explore',
+    links: [
+      { label: 'About', href: '/about' },
+      { label: 'Projects', href: '/projects' },
+      { label: 'Résumé', href: '/resume' },
+      { label: 'Contact', href: '/contact' },
+    ],
+  },
+  {
+    heading: 'Revenue Operations',
+    links: [
+      { label: 'All articles', href: '/blog' },
+      { label: 'RevOps insights', href: '/blog/category/revenue-operations' },
+    ],
+  },
+  {
+    heading: 'Popular guides',
+    links: [
+      {
+        label: 'Lead scoring models that work',
+        href: '/blog/lead-scoring-models-that-actually-work',
+      },
+      {
+        label: 'Multi-touch attribution',
+        href: '/blog/multi-touch-attribution-modeling-best-practices',
+      },
+      {
+        label: 'Revenue intelligence platforms',
+        href: '/blog/stop-guessing-how-revenue-intelligence-platforms-slash-forecast-errors-by-40',
+      },
+      {
+        label: 'Customer churn analysis (Python)',
+        href: '/blog/advanced-customer-churn-analysis-python',
+      },
+    ],
+  },
+]
+
 export function Footer() {
   const currentYear = new Date().getFullYear()
 
   return (
-    <footer className="bg-card border-t border-border py-4">
-      <div className="w-full mx-auto px-4 max-w-7xl">
-        <div className="flex flex-col md:flex-row justify-between items-center gap-3 text-sm text-muted-foreground">
+    <footer className="bg-card border-t border-border">
+      <div className="w-full mx-auto px-4 sm:px-6 lg:px-8 max-w-7xl py-12">
+        <div className="grid grid-cols-2 gap-8 md:grid-cols-4">
+          {/* Brand / intro column */}
+          <div className="col-span-2 md:col-span-1">
+            <Link href="/" className="font-display text-lg font-semibold text-foreground">
+              Richard Hudson
+            </Link>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Revenue Operations — forecasting, pipeline, and GTM analytics for B2B SaaS.
+            </p>
+          </div>
+
+          {FOOTER_SECTIONS.map((section) => (
+            <nav key={section.heading} aria-label={section.heading}>
+              <h2 className="text-xs font-semibold uppercase tracking-wider text-foreground">
+                {section.heading}
+              </h2>
+              <ul className="mt-3 space-y-2">
+                {section.links.map((link) => (
+                  <li key={link.href}>
+                    <Link
+                      href={link.href}
+                      className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                    >
+                      {link.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          ))}
+        </div>
+
+        <div className="mt-10 pt-6 border-t border-border flex flex-col md:flex-row justify-between items-center gap-3 text-sm text-muted-foreground">
           <p>© {currentYear} Richard Hudson. All rights reserved.</p>
           <a
             href="https://hudsondigitalsolutions.com"


### PR DESCRIPTION
**Why:** GSC shows **8 pages indexed / 52 not indexed (41 "Discovered – currently not indexed")** with **~1 external backlink** — a crawl-priority problem, not a content or canonical problem (zero canonical/dup errors; all 48 sitemap URLs return 200). Google rations crawl for low-authority domains, so most posts never get crawled.

The footer was the one real internal-linking gap — it had **zero internal links** (only the outbound "Built by Hudson Digital Solutions" link), despite rendering on *every* page including the handful Google actually indexes. Internal footer links distribute crawl priority + authority from those indexed pages down into the category hubs and cornerstone posts.

**What changed:** a proper 4-column footer — brand blurb + Explore (About/Projects/Résumé/Contact) + Revenue Operations (`/blog`, `/blog/category/revenue-operations`) + Popular guides (4 cornerstone posts). Kept the existing outbound business link + copyright.

All links are **GSC-confirmed-live (200)** cornerstone/indexed URLs — `lead-scoring-models-that-actually-work`, `multi-touch-attribution-modeling-best-practices`, `stop-guessing-how-revenue-intelligence-platforms-slash-forecast-errors-by-40`, `advanced-customer-churn-analysis-python` — so nothing 404s and the links reinforce pages already earning impressions.

**Verification:** `typecheck` ✓ · `biome` ✓ · `vitest` 1037 ✓ · `build` ✓

> Note: this is a *marginal* SEO win. The internal-linking plumbing was already mostly sound (nav→/blog, /blog→all posts, post→3 related posts). The real ceiling is **backlinks** (1 → needs dozens) — tracked separately.

[hudsor01]