### PR TITLE
feat(tools): Pipeline Coverage Calculator — win-rate-driven, first linkable SEO asset

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -128,9 +128,9 @@ const nextConfig = {
           { key: 'Vary', value: 'Accept-Encoding' },
         ],
       },
-      // ISR + dynamic content caching for blog/project pages.
+      // ISR + dynamic content caching for blog/project/tool pages.
       {
-        source: '/(projects|blog)/:path*',
+        source: '/(projects|blog|tools)/:path*',
         headers: [
           { key: 'Cache-Control', value: 's-maxage=60, stale-while-revalidate=86400' },
           { key: 'CDN-Cache-Control', value: 'max-age=3600' },

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -89,6 +89,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'daily',
       priority: 0.9,
     },
+    {
+      url: `${baseUrl}/tools/pipeline-coverage-calculator`,
+      lastModified: staticLastModified,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
   ]
 
   // All project pages (complete list).

--- a/src/app/tools/pipeline-coverage-calculator/_components/pipeline-coverage-calculator.tsx
+++ b/src/app/tools/pipeline-coverage-calculator/_components/pipeline-coverage-calculator.tsx
@@ -1,0 +1,280 @@
+'use client'
+
+import { useId, useMemo, useState } from 'react'
+import { computeCoverage, COVERAGE_PRESETS } from '@/lib/pipeline-coverage'
+
+const usd0 = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 0,
+})
+const usdCompact = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  notation: 'compact',
+  maximumFractionDigits: 1,
+})
+function money(n: number): string {
+  return Math.abs(n) >= 1_000_000 ? usdCompact.format(n) : usd0.format(n)
+}
+function mult(n: number): string {
+  return `${n.toFixed(1)}×`
+}
+/** Empty string → undefined; otherwise the parsed number (NaN-safe via the lib). */
+function parse(v: string): number | undefined {
+  if (v.trim() === '') return undefined
+  const n = Number(v)
+  return Number.isFinite(n) ? n : Number.NaN
+}
+
+const inputClass =
+  'w-full px-4 py-3 bg-background border border-border rounded-xl text-foreground placeholder-muted-foreground focus:outline-hidden focus:ring-[3px] focus:ring-primary/20 focus:border-primary transition-all'
+
+export function PipelineCoverageCalculator() {
+  const ids = {
+    target: useId(),
+    win: useId(),
+    deal: useId(),
+    pipe: useId(),
+    qual: useId(),
+    safety: useId(),
+  }
+  const [target, setTarget] = useState('1000000')
+  const [winRate, setWinRate] = useState('25')
+  const [avgDeal, setAvgDeal] = useState('')
+  const [currentPipe, setCurrentPipe] = useState('')
+  const [qualified, setQualified] = useState('100')
+  const [safety, setSafety] = useState('0')
+
+  const result = useMemo(
+    () =>
+      computeCoverage({
+        revenueTarget: parse(target) ?? Number.NaN,
+        winRatePct: parse(winRate) ?? Number.NaN,
+        avgDealSize: parse(avgDeal),
+        currentPipeline: parse(currentPipe),
+        qualifiedRatePct: parse(qualified),
+        safetyMarginPct: parse(safety),
+      }),
+    [target, winRate, avgDeal, currentPipe, qualified, safety]
+  )
+
+  return (
+    <div className="grid gap-8 lg:grid-cols-2">
+      {/* Inputs */}
+      <div className="bg-card rounded-2xl p-6 sm:p-8 border border-border shadow-sm">
+        <h2 className="text-lg font-semibold text-foreground mb-6">Your numbers</h2>
+
+        <div className="space-y-5">
+          <Field id={ids.target} label="Revenue target (this period)" prefix="$">
+            <input
+              id={ids.target}
+              type="number"
+              min="0"
+              inputMode="numeric"
+              value={target}
+              onChange={(e) => setTarget(e.target.value)}
+              className={`${inputClass} pl-8`}
+              placeholder="1,000,000"
+            />
+          </Field>
+
+          <div>
+            <Field id={ids.win} label="Win rate" suffix="%">
+              <input
+                id={ids.win}
+                type="number"
+                min="0"
+                max="100"
+                inputMode="decimal"
+                value={winRate}
+                onChange={(e) => setWinRate(e.target.value)}
+                className={`${inputClass} pr-8`}
+                placeholder="25"
+              />
+            </Field>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {COVERAGE_PRESETS.map((p) => (
+                <button
+                  key={p.id}
+                  type="button"
+                  onClick={() => setWinRate(String(p.winRatePct))}
+                  className="text-xs px-3 py-1 rounded-full border border-border bg-background text-muted-foreground hover:border-primary hover:text-primary transition-colors"
+                >
+                  {p.label} ({p.winRatePct}%)
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <Field id={ids.deal} label="Average deal size (optional)" prefix="$">
+            <input
+              id={ids.deal}
+              type="number"
+              min="0"
+              inputMode="numeric"
+              value={avgDeal}
+              onChange={(e) => setAvgDeal(e.target.value)}
+              className={`${inputClass} pl-8`}
+              placeholder="50,000"
+            />
+          </Field>
+
+          <Field id={ids.pipe} label="Open pipeline today (optional)" prefix="$">
+            <input
+              id={ids.pipe}
+              type="number"
+              min="0"
+              inputMode="numeric"
+              value={currentPipe}
+              onChange={(e) => setCurrentPipe(e.target.value)}
+              className={`${inputClass} pl-8`}
+              placeholder="3,000,000"
+            />
+          </Field>
+
+          <div className="grid grid-cols-2 gap-4">
+            <Field id={ids.qual} label="% truly qualified" suffix="%">
+              <input
+                id={ids.qual}
+                type="number"
+                min="0"
+                max="100"
+                value={qualified}
+                onChange={(e) => setQualified(e.target.value)}
+                className={`${inputClass} pr-8`}
+                placeholder="100"
+              />
+            </Field>
+            <Field id={ids.safety} label="Safety margin" suffix="%">
+              <input
+                id={ids.safety}
+                type="number"
+                min="0"
+                value={safety}
+                onChange={(e) => setSafety(e.target.value)}
+                className={`${inputClass} pr-8`}
+                placeholder="0"
+              />
+            </Field>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            “% truly qualified” strips stalled/zombie deals from your current pipeline so the gap
+            reflects what can actually close.
+          </p>
+        </div>
+      </div>
+
+      {/* Results */}
+      <div
+        className="bg-card rounded-2xl p-6 sm:p-8 border border-border shadow-sm"
+        aria-live="polite"
+      >
+        {!result.valid ? (
+          <div className="h-full flex items-center justify-center text-center">
+            <p className="text-muted-foreground">{result.error}</p>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            <div>
+              <p className="text-sm uppercase tracking-wider text-muted-foreground">
+                Required coverage
+              </p>
+              <p className="text-5xl font-bold text-primary tracking-tight">
+                {mult(result.requiredCoverage)}
+              </p>
+              <p className="mt-1 text-foreground">
+                ≈ <strong>{money(result.requiredPipeline)}</strong> in qualified pipeline to hit{' '}
+                {money(parse(target) ?? 0)}.
+              </p>
+            </div>
+
+            <div className="rounded-xl bg-muted/50 p-4 text-sm">
+              <p className="text-foreground">
+                The generic <strong>3× rule</strong> would tell you to build{' '}
+                {money(result.lazyThreeXPipeline)} —{' '}
+                {result.vsLazyThreeX > 0 ? (
+                  <span className="text-destructive font-medium">
+                    {money(Math.abs(result.vsLazyThreeX))} too little
+                  </span>
+                ) : result.vsLazyThreeX < 0 ? (
+                  <span className="text-success font-medium">
+                    {money(Math.abs(result.vsLazyThreeX))} more than you need
+                  </span>
+                ) : (
+                  <span className="font-medium">exactly right (rare)</span>
+                )}{' '}
+                at a {winRate}% win rate.
+              </p>
+            </div>
+
+            {result.oppsNeeded !== undefined && result.dealsToWin !== undefined && (
+              <div className="text-sm text-foreground">
+                That’s ≈ <strong>{Math.ceil(result.oppsNeeded).toLocaleString()}</strong> qualified
+                opps in flight to win the{' '}
+                <strong>{Math.ceil(result.dealsToWin).toLocaleString()}</strong> deals you need.
+              </div>
+            )}
+
+            {result.pipelineGap !== undefined && result.currentCoverage !== undefined && (
+              <div className="rounded-xl border border-border p-4">
+                <p className="text-sm text-muted-foreground">
+                  You have {mult(result.currentCoverage)} coverage today
+                  {result.effectiveCurrentPipeline !== undefined &&
+                    ` (${money(result.effectiveCurrentPipeline)} qualified)`}
+                  .
+                </p>
+                <p className="mt-1 font-semibold">
+                  {result.pipelineGap > 0.5 ? (
+                    <span className="text-destructive">
+                      Shortfall: build {money(result.pipelineGap)} more pipeline.
+                    </span>
+                  ) : (
+                    <span className="text-success">
+                      Surplus: {money(Math.abs(result.pipelineGap))} above target coverage.
+                    </span>
+                  )}
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Field({
+  id,
+  label,
+  prefix,
+  suffix,
+  children,
+}: {
+  id: string
+  label: string
+  prefix?: string
+  suffix?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div>
+      <label htmlFor={id} className="block text-sm font-medium text-foreground mb-1.5">
+        {label}
+      </label>
+      <div className="relative">
+        {prefix && (
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
+            {prefix}
+          </span>
+        )}
+        {children}
+        {suffix && (
+          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground">
+            {suffix}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/tools/pipeline-coverage-calculator/page.tsx
+++ b/src/app/tools/pipeline-coverage-calculator/page.tsx
@@ -1,0 +1,183 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { Navbar } from '@/components/layout/navbar'
+import { FAQPageJsonLd } from '@/components/seo/json-ld/faq-json-ld'
+import { BreadcrumbListJsonLd } from '@/components/seo/json-ld/breadcrumb-json-ld'
+import { canonicalUrl, SITE_ORIGIN } from '@/lib/absolute-url'
+import { PipelineCoverageCalculator } from './_components/pipeline-coverage-calculator'
+
+const PATH = '/tools/pipeline-coverage-calculator'
+const TITLE = 'Pipeline Coverage Calculator — Win-Rate-Driven (Not the 3× Rule)'
+const DESCRIPTION =
+  'Free pipeline coverage calculator. Enter your win rate and revenue target to get the exact coverage ratio and qualified pipeline you actually need — driven by win rate, not the generic 3× rule.'
+
+const OG_IMAGE = canonicalUrl(
+  `/api/og?${new URLSearchParams({
+    title: 'Pipeline Coverage Calculator',
+    subtitle: 'Win-rate-driven, not the 3× rule',
+  }).toString()}`
+)
+
+const FAQS: Array<{ question: string; answer: string }> = [
+  {
+    question: 'What is pipeline coverage?',
+    answer:
+      'Pipeline coverage is the ratio of open pipeline value to your revenue target for the period. A 4× coverage means you have four dollars of open pipeline for every dollar of quota. It tells you whether you have enough pipeline to realistically hit the number.',
+  },
+  {
+    question: 'What is a good pipeline coverage ratio?',
+    answer:
+      'It depends entirely on your win rate: required coverage ≈ 1 ÷ win rate. A team that wins 25% of qualified opportunities needs about 4× coverage; at a 40% win rate you need ~2.5×; at 15% you need ~6.7×. The flat “3× rule” only happens to fit a ~33% win rate.',
+  },
+  {
+    question: 'How do I calculate the pipeline I need to hit quota?',
+    answer:
+      'Required pipeline = revenue target ÷ win rate, optionally multiplied by a safety margin for slippage and timing. For a $1M target at a 25% win rate, you need $1,000,000 ÷ 0.25 = $4,000,000 of qualified pipeline.',
+  },
+  {
+    question: 'Why is the 3× pipeline rule misleading?',
+    answer:
+      'Because it ignores win rate. Teams with a low win rate badly under-build pipeline if they trust 3×, and high-win-rate teams waste reps’ time over-building. Coverage should be derived from your actual win rate, not a one-size-fits-all constant.',
+  },
+  {
+    question: 'Should I count all of my open pipeline?',
+    answer:
+      'No. Strip out stalled and zombie deals first — opportunities with no recent activity, no compelling event, or a long-past close date. Coverage should be measured against genuinely qualified pipeline, which is why this calculator includes a “% truly qualified” haircut.',
+  },
+]
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  keywords: [
+    'pipeline coverage calculator',
+    'pipeline coverage ratio',
+    'how much pipeline do I need',
+    'sales pipeline coverage',
+    'required pipeline coverage',
+    'win rate coverage ratio',
+  ],
+  alternates: { canonical: canonicalUrl(PATH) },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: canonicalUrl(PATH),
+    type: 'website',
+    images: [{ url: OG_IMAGE, width: 1200, height: 630, alt: 'Pipeline Coverage Calculator' }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    creator: '@hudsor01',
+    title: TITLE,
+    description: DESCRIPTION,
+    images: [OG_IMAGE],
+  },
+}
+
+export default function PipelineCoverageCalculatorPage() {
+  return (
+    <>
+      <BreadcrumbListJsonLd
+        items={[
+          { name: 'Home', url: SITE_ORIGIN },
+          { name: 'Pipeline Coverage Calculator', url: canonicalUrl(PATH) },
+        ]}
+      />
+      <FAQPageJsonLd faqs={FAQS} />
+
+      <div className="min-h-screen bg-background">
+        <Navbar />
+        <main id="main-content" className="max-w-5xl mx-auto px-6 lg:px-8 pt-24 pb-20 lg:pt-32">
+          <header className="mb-10">
+            <p className="text-sm text-muted-foreground mb-3">
+              <Link href="/" className="hover:text-primary">
+                Home
+              </Link>{' '}
+              / Pipeline Coverage Calculator
+            </p>
+            <h1 className="font-display text-4xl md:text-5xl font-bold text-foreground tracking-tight mb-4">
+              Pipeline Coverage Calculator
+            </h1>
+            <p className="text-lg text-muted-foreground max-w-3xl leading-relaxed">
+              How much pipeline do you actually need to hit your number? Not 3× — that’s a guess.
+              The honest answer is driven by your <strong>win rate</strong>. Enter yours below to
+              get the coverage ratio and qualified pipeline you really need.
+            </p>
+          </header>
+
+          <PipelineCoverageCalculator />
+
+          <section className="mt-16 max-w-3xl">
+            <h2 className="text-2xl font-semibold text-foreground mb-4">
+              Why the “3× pipeline” rule is wrong for most teams
+            </h2>
+            <div className="space-y-4 text-muted-foreground leading-relaxed">
+              <p>
+                The 3× rule is everywhere because it’s easy to remember — but it’s only correct for
+                a team winning roughly one in three qualified opportunities. The real relationship
+                is simple: <strong>required coverage ≈ 1 ÷ win rate.</strong>
+              </p>
+              <p>
+                If you win <strong>15%</strong> of opps, 3× coverage leaves you ~55% short of the
+                pipeline you need — you’ll miss quota while believing you’re covered. If you win{' '}
+                <strong>40%</strong>, 3× has your reps chasing 17% more pipeline than necessary,
+                burning capacity that should go into working live deals.
+              </p>
+              <p>
+                Coverage also only counts pipeline that can actually close. Stalled deals, no
+                compelling event, close dates three quarters in the past — strip them out with the
+                “% truly qualified” control, because covered-on-paper isn’t covered.
+              </p>
+            </div>
+          </section>
+
+          <section className="mt-12 max-w-3xl">
+            <h2 className="text-2xl font-semibold text-foreground mb-6">
+              Frequently asked questions
+            </h2>
+            <dl className="space-y-6">
+              {FAQS.map((faq) => (
+                <div key={faq.question}>
+                  <dt className="font-semibold text-foreground">{faq.question}</dt>
+                  <dd className="mt-1 text-muted-foreground leading-relaxed">{faq.answer}</dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+
+          <section className="mt-12 pt-8 border-t border-border max-w-3xl">
+            <h2 className="text-xl font-semibold text-foreground mb-4">Related reading</h2>
+            <ul className="space-y-2 text-primary">
+              <li>
+                <Link
+                  href="/blog/stop-guessing-how-we-slashed-forecast-variance-by-34-in-90-days"
+                  className="hover:underline"
+                >
+                  How we slashed forecast variance by 34% in 90 days
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/blog/lead-scoring-models-that-actually-work"
+                  className="hover:underline"
+                >
+                  Lead scoring models that actually work
+                </Link>
+              </li>
+              <li>
+                <Link href="/projects/forecast-pipeline-intelligence" className="hover:underline">
+                  Case study: Forecast &amp; Pipeline Intelligence
+                </Link>
+              </li>
+              <li>
+                <Link href="/projects/deal-funnel" className="hover:underline">
+                  Case study: Deal Funnel optimization
+                </Link>
+              </li>
+            </ul>
+          </section>
+        </main>
+      </div>
+    </>
+  )
+}

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -23,6 +23,7 @@ const FOOTER_SECTIONS: ReadonlyArray<{
     links: [
       { label: 'All articles', href: '/blog' },
       { label: 'RevOps insights', href: '/blog/category/revenue-operations' },
+      { label: 'Pipeline coverage calculator', href: '/tools/pipeline-coverage-calculator' },
     ],
   },
   {

--- a/src/lib/__tests__/pipeline-coverage.test.ts
+++ b/src/lib/__tests__/pipeline-coverage.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import { computeCoverage, COVERAGE_PRESETS, type CoverageInput } from '@/lib/pipeline-coverage'
+
+const base: CoverageInput = { revenueTarget: 1_000_000, winRatePct: 25 }
+
+describe('computeCoverage — core math', () => {
+  it('coverage = 1/winRate (25% → 4×, $1M → $4M pipeline)', () => {
+    const r = computeCoverage(base)
+    expect(r.valid).toBe(true)
+    expect(r.requiredCoverage).toBeCloseTo(4, 6)
+    expect(r.requiredPipeline).toBeCloseTo(4_000_000, 2)
+    expect(r.winRate).toBeCloseTo(0.25, 6)
+  })
+
+  it('40% win → 2.5× (the generic 3× OVER-builds)', () => {
+    const r = computeCoverage({ revenueTarget: 1_000_000, winRatePct: 40 })
+    expect(r.requiredCoverage).toBeCloseTo(2.5, 6)
+    expect(r.requiredPipeline).toBeCloseTo(2_500_000, 2)
+    expect(r.vsLazyThreeX).toBeCloseTo(-500_000, 2) // negative = 3× over-builds
+  })
+
+  it('15% win → ~6.67× (the generic 3× UNDER-builds badly)', () => {
+    const r = computeCoverage({ revenueTarget: 1_000_000, winRatePct: 15 })
+    expect(r.requiredCoverage).toBeCloseTo(1 / 0.15, 6)
+    expect(r.vsLazyThreeX).toBeGreaterThan(0) // positive = 3× under-builds
+  })
+
+  it('100% win → exactly 1× coverage', () => {
+    const r = computeCoverage({ revenueTarget: 500_000, winRatePct: 100 })
+    expect(r.requiredCoverage).toBeCloseTo(1, 6)
+    expect(r.requiredPipeline).toBeCloseTo(500_000, 2)
+  })
+
+  it('safety margin multiplies coverage (10% buffer → 4.4×)', () => {
+    const r = computeCoverage({ ...base, safetyMarginPct: 10 })
+    expect(r.requiredCoverage).toBeCloseTo(4.4, 6)
+    expect(r.requiredPipeline).toBeCloseTo(4_400_000, 2)
+  })
+})
+
+describe('computeCoverage — deals & opps', () => {
+  it('derives dealsToWin and oppsNeeded from avg deal size', () => {
+    const r = computeCoverage({ ...base, avgDealSize: 50_000 })
+    expect(r.dealsToWin).toBeCloseTo(20, 6) // 1M / 50k
+    expect(r.oppsNeeded).toBeCloseTo(80, 6) // 20 / 0.25
+  })
+
+  it('omits deal/opp counts when avg deal size is missing or non-positive', () => {
+    expect(computeCoverage(base).oppsNeeded).toBeUndefined()
+    expect(computeCoverage({ ...base, avgDealSize: 0 }).oppsNeeded).toBeUndefined()
+    expect(computeCoverage({ ...base, avgDealSize: -5 }).dealsToWin).toBeUndefined()
+  })
+})
+
+describe('computeCoverage — current pipeline + qualified haircut', () => {
+  it('computes shortfall gap against current pipeline', () => {
+    const r = computeCoverage({ ...base, currentPipeline: 3_000_000 })
+    expect(r.effectiveCurrentPipeline).toBeCloseTo(3_000_000, 2)
+    expect(r.currentCoverage).toBeCloseTo(3, 6)
+    expect(r.pipelineGap).toBeCloseTo(1_000_000, 2) // need 4M, have 3M → 1M short
+  })
+
+  it('qualified-rate haircut strips stalled pipeline from the effective total', () => {
+    const r = computeCoverage({ ...base, currentPipeline: 3_000_000, qualifiedRatePct: 80 })
+    expect(r.effectiveCurrentPipeline).toBeCloseTo(2_400_000, 2) // 3M × 0.8
+    expect(r.pipelineGap).toBeCloseTo(1_600_000, 2) // need 4M, only 2.4M counts
+  })
+
+  it('reports a surplus (negative gap) when over-covered', () => {
+    const r = computeCoverage({
+      revenueTarget: 1_000_000,
+      winRatePct: 25,
+      currentPipeline: 5_000_000,
+    })
+    expect(r.pipelineGap).toBeCloseTo(-1_000_000, 2) // 4M needed, 5M have → 1M surplus
+  })
+
+  it('accepts a legitimate zero current pipeline (full gap)', () => {
+    const r = computeCoverage({ ...base, currentPipeline: 0 })
+    expect(r.effectiveCurrentPipeline).toBe(0)
+    expect(r.pipelineGap).toBeCloseTo(4_000_000, 2)
+  })
+})
+
+describe('computeCoverage — validation & adversarial inputs', () => {
+  it('rejects non-positive revenue target', () => {
+    expect(computeCoverage({ revenueTarget: 0, winRatePct: 25 }).valid).toBe(false)
+    expect(computeCoverage({ revenueTarget: -100, winRatePct: 25 }).valid).toBe(false)
+  })
+
+  it('rejects win rate ≤ 0 or > 100', () => {
+    expect(computeCoverage({ revenueTarget: 1_000_000, winRatePct: 0 }).valid).toBe(false)
+    expect(computeCoverage({ revenueTarget: 1_000_000, winRatePct: -10 }).valid).toBe(false)
+    expect(computeCoverage({ revenueTarget: 1_000_000, winRatePct: 120 }).valid).toBe(false)
+  })
+
+  it('never divides by zero or returns NaN/Infinity on valid inputs', () => {
+    for (let w = 1; w <= 100; w++) {
+      const r = computeCoverage({ revenueTarget: 1_000_000, winRatePct: w })
+      expect(Number.isFinite(r.requiredCoverage)).toBe(true)
+      expect(Number.isFinite(r.requiredPipeline)).toBe(true)
+      expect(r.requiredPipeline).toBeGreaterThan(0)
+    }
+  })
+
+  it('survives NaN / Infinity garbage without throwing or producing NaN output', () => {
+    const garbage = computeCoverage({
+      revenueTarget: Number.NaN,
+      winRatePct: Number.POSITIVE_INFINITY,
+      avgDealSize: Number.NaN,
+      currentPipeline: Number.POSITIVE_INFINITY,
+      qualifiedRatePct: Number.NaN,
+      safetyMarginPct: Number.NaN,
+    })
+    expect(garbage.valid).toBe(false) // NaN target → invalid, no throw
+  })
+
+  it('clamps an out-of-range qualified rate instead of distorting the result', () => {
+    const over = computeCoverage({ ...base, currentPipeline: 1_000_000, qualifiedRatePct: 150 })
+    expect(over.effectiveCurrentPipeline).toBeCloseTo(1_000_000, 2) // clamped to 100%
+    const under = computeCoverage({ ...base, currentPipeline: 1_000_000, qualifiedRatePct: -20 })
+    expect(under.effectiveCurrentPipeline).toBe(0) // clamped to 0%
+  })
+
+  it('handles very large targets without overflow', () => {
+    const r = computeCoverage({ revenueTarget: 5_000_000_000, winRatePct: 20 })
+    expect(r.requiredPipeline).toBeCloseTo(25_000_000_000, 0)
+    expect(Number.isFinite(r.requiredPipeline)).toBe(true)
+  })
+})
+
+describe('COVERAGE_PRESETS', () => {
+  it('every preset produces a valid result with sane coverage', () => {
+    for (const p of COVERAGE_PRESETS) {
+      const r = computeCoverage({ revenueTarget: 1_000_000, winRatePct: p.winRatePct })
+      expect(r.valid).toBe(true)
+      expect(r.requiredCoverage).toBeGreaterThan(1)
+      expect(r.requiredCoverage).toBeLessThan(10)
+    }
+  })
+})

--- a/src/lib/pipeline-coverage.ts
+++ b/src/lib/pipeline-coverage.ts
@@ -1,0 +1,132 @@
+/**
+ * Win-rate-driven pipeline coverage math.
+ *
+ * The "3× pipeline" rule of thumb is wrong for most teams: required coverage is
+ * a function of win rate, not a constant. A team that wins 40% of qualified
+ * opps needs ~2.5× coverage; one that wins 15% needs ~6.7×. This module is the
+ * pure, side-effect-free core behind the Pipeline Coverage Calculator so it can
+ * be unit-tested to the edges independent of the UI.
+ *
+ *   required coverage  = (1 / winRate) × (1 + safetyMargin)
+ *   required pipeline  = revenueTarget × required coverage
+ */
+
+export interface CoverageInput {
+  /** Revenue target / quota for the period, in dollars. Required, > 0. */
+  revenueTarget: number
+  /** Expected win rate of qualified opportunities, 0–100. Required, > 0, ≤ 100. */
+  winRatePct: number
+  /** Average deal size in dollars. Optional — enables deal/opp counts. */
+  avgDealSize?: number
+  /** Open pipeline you have today, in dollars. Optional — enables the gap. */
+  currentPipeline?: number
+  /** % of `currentPipeline` that is genuinely active/qualified (strips stalled/zombie deals). Default 100. */
+  qualifiedRatePct?: number
+  /** Extra buffer for slippage/timing, as a %. Default 0. */
+  safetyMarginPct?: number
+}
+
+export interface CoverageResult {
+  valid: boolean
+  /** Present only when `valid` is false. */
+  error?: string
+  /** Win rate as a decimal (0–1). */
+  winRate: number
+  /** Required coverage multiple (e.g. 4 means "4× your target in pipeline"). */
+  requiredCoverage: number
+  /** Required open pipeline in dollars to hit the target. */
+  requiredPipeline: number
+  /** currentPipeline × qualifiedRate — the pipeline that actually counts. */
+  effectiveCurrentPipeline?: number
+  /** effectiveCurrentPipeline ÷ target, as a multiple. */
+  currentCoverage?: number
+  /** requiredPipeline − effectiveCurrentPipeline. Positive = shortfall, negative = surplus. */
+  pipelineGap?: number
+  /** Deals you must win to hit target (target ÷ avgDealSize). */
+  dealsToWin?: number
+  /** Qualified opps you need in pipeline (dealsToWin ÷ winRate × safety). */
+  oppsNeeded?: number
+  /** What the generic "3× rule" would tell you to build. */
+  lazyThreeXPipeline: number
+  /** requiredPipeline − lazyThreeXPipeline. Positive = 3× under-builds; negative = 3× over-builds. */
+  vsLazyThreeX: number
+}
+
+/** Finite positive number, else undefined. */
+function pos(v: number | undefined): number | undefined {
+  return typeof v === 'number' && Number.isFinite(v) && v > 0 ? v : undefined
+}
+
+/** Clamp to [min, max]; non-finite falls back to `fallback`. */
+function clamp(v: number | undefined, min: number, max: number, fallback: number): number {
+  if (typeof v !== 'number' || !Number.isFinite(v)) return fallback
+  return Math.min(max, Math.max(min, v))
+}
+
+export function computeCoverage(input: CoverageInput): CoverageResult {
+  const target = pos(input.revenueTarget)
+  const winRatePct = input.winRatePct
+
+  if (target === undefined) {
+    return invalid('Enter a revenue target greater than $0.')
+  }
+  if (typeof winRatePct !== 'number' || !Number.isFinite(winRatePct) || winRatePct <= 0) {
+    return invalid('Win rate must be greater than 0%.')
+  }
+  if (winRatePct > 100) {
+    return invalid('Win rate can’t exceed 100%.')
+  }
+
+  const winRate = winRatePct / 100
+  const safety = 1 + clamp(input.safetyMarginPct, 0, 1000, 0) / 100
+  const qualifiedRate = clamp(input.qualifiedRatePct, 0, 100, 100) / 100
+
+  const requiredCoverage = (1 / winRate) * safety
+  const requiredPipeline = target * requiredCoverage
+  const lazyThreeXPipeline = target * 3
+
+  const result: CoverageResult = {
+    valid: true,
+    winRate,
+    requiredCoverage,
+    requiredPipeline,
+    lazyThreeXPipeline,
+    vsLazyThreeX: requiredPipeline - lazyThreeXPipeline,
+  }
+
+  const avgDeal = pos(input.avgDealSize)
+  if (avgDeal !== undefined) {
+    result.dealsToWin = target / avgDeal
+    result.oppsNeeded = (target / avgDeal / winRate) * safety
+  }
+
+  // currentPipeline may legitimately be 0 (no pipeline yet), so accept >= 0.
+  const current = input.currentPipeline
+  if (typeof current === 'number' && Number.isFinite(current) && current >= 0) {
+    const effective = current * qualifiedRate
+    result.effectiveCurrentPipeline = effective
+    result.currentCoverage = effective / target
+    result.pipelineGap = requiredPipeline - effective
+  }
+
+  return result
+}
+
+function invalid(error: string): CoverageResult {
+  return {
+    valid: false,
+    error,
+    winRate: 0,
+    requiredCoverage: 0,
+    requiredPipeline: 0,
+    lazyThreeXPipeline: 0,
+    vsLazyThreeX: 0,
+  }
+}
+
+/** Segment presets — typical win rates by motion (directional industry ranges). */
+export const COVERAGE_PRESETS = [
+  { id: 'smb', label: 'SMB / transactional', winRatePct: 35 },
+  { id: 'midmarket', label: 'Mid-market', winRatePct: 25 },
+  { id: 'enterprise', label: 'Enterprise', winRatePct: 18 },
+] as const


### PR DESCRIPTION
The #1 idea from the content-traffic research, built and battle-tested. A free interactive **Pipeline Coverage Calculator** at `/tools/pipeline-coverage-calculator` — the most link-magnetic, hardest-to-copy format in the RevOps niche, and exactly the asset class that earns the backlinks this site needs (currently **1 referring domain**).

## The differentiator
Coverage is derived from **win rate** (`coverage ≈ 1 ÷ win-rate`), **not** the lazy "3× rule" — which the competing pages all parrot. The tool shows, for *your* win rate, how much the 3× rule over- or under-builds. Plus: segment presets, a deals/opps breakdown, a current-pipeline gap, and a **"% truly qualified" haircut** that strips stalled/zombie deals.

## Built to be battle-tested
- **`src/lib/pipeline-coverage.ts`** — pure, side-effect-free math core.
- **`src/lib/__tests__/pipeline-coverage.test.ts`** — **18 tests**: known values (25%→4×, $1M→$4M), boundaries (0%/100% win), the 3× over/under-build comparison, the qualified haircut, **and adversarial inputs** (NaN / Infinity / negative / out-of-range) that must never throw or emit NaN/Infinity.

## SEO + crawlability (ties into the indexing work)
- Static-content page: `<h1>`, a "why 3× is wrong" explainer, a **visible FAQ + `FAQPage` JSON-LD** (position-zero/PAA capture) + breadcrumb schema, keyword-targeted metadata/OG.
- **Internal links** into the forecasting cluster + case studies (and the tool is wired into the **footer** sitewide + the **sitemap**, so it actually gets crawled).
- Extended the CDN-cache rule to `/tools/*`.

## Verification
`typecheck` ✓ · `biome` ✓ · `vitest` **1055** ✓ · `build` ✓ (route renders, in sitemap)

> Strategic note: this is the first **Tier-2 (authority)** asset — the real lever for traffic. It's designed to be cited/linked by other RevOps blogs. Pair it with distribution (LinkedIn, RevOps communities) to start earning referring domains.

[hudsor01]