### PR TITLE
fix(seo): retry transient DB reads so a Neon blip during crawl isn't a 5xx

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -11,6 +11,7 @@ import { transformToBlogPostData } from '@/lib/api-blog'
 import { createContextLogger } from '@/lib/logger'
 import type { BlogPostData } from '@/types/api'
 import { db } from '@/lib/db'
+import { withDbRetry } from '@/lib/db-retry'
 import { blogPosts } from '@/db/schema'
 import { canonicalUrl } from '@/lib/absolute-url'
 import { safeFeaturedImageUrl } from '@/lib/featured-image-url'
@@ -43,14 +44,16 @@ interface BlogPostPageProps {
 // status check; no post-fetch JS filtering.
 const getBlogPost = cache(async (slug: string): Promise<BlogPostData | null> => {
   try {
-    const post = await db.query.blogPosts.findFirst({
-      where: and(eq(blogPosts.slug, slug), eq(blogPosts.status, 'PUBLISHED')),
-      with: {
-        author: true,
-        category: true,
-        tags: { with: { tag: true } },
-      },
-    })
+    const post = await withDbRetry(() =>
+      db.query.blogPosts.findFirst({
+        where: and(eq(blogPosts.slug, slug), eq(blogPosts.status, 'PUBLISHED')),
+        with: {
+          author: true,
+          category: true,
+          tags: { with: { tag: true } },
+        },
+      })
+    )
 
     if (!post) return null
     if (post.deletedAt) return null
@@ -201,12 +204,14 @@ export async function generateStaticParams() {
   }
 
   try {
-    const posts = await db
-      .select({ slug: blogPosts.slug })
-      .from(blogPosts)
-      // Exclude soft-deleted posts so the build doesn't prerender slugs
-      // that runtime getBlogPost now rejects with notFound() → HTTP 404.
-      .where(and(eq(blogPosts.status, 'PUBLISHED'), isNull(blogPosts.deletedAt)))
+    const posts = await withDbRetry(() =>
+      db
+        .select({ slug: blogPosts.slug })
+        .from(blogPosts)
+        // Exclude soft-deleted posts so the build doesn't prerender slugs
+        // that runtime getBlogPost now rejects with notFound() → HTTP 404.
+        .where(and(eq(blogPosts.status, 'PUBLISHED'), isNull(blogPosts.deletedAt)))
+    )
 
     return posts.map((post) => ({ slug: post.slug }))
   } catch (error) {

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -8,6 +8,7 @@ import { BreadcrumbListJsonLd } from '@/components/seo/json-ld/breadcrumb-json-l
 import { ItemListJsonLd } from '@/components/seo/json-ld/item-list-json-ld'
 import { and, desc, eq, isNull } from 'drizzle-orm'
 import { db } from '@/lib/db'
+import { withDbRetry } from '@/lib/db-retry'
 import { blogPosts, categories as categoriesTable } from '@/db/schema'
 import { transformToBlogPostData } from '@/lib/api-blog'
 import { createContextLogger } from '@/lib/logger'
@@ -62,18 +63,20 @@ const getBlogPosts = cache(async (): Promise<BlogPostData[]> => {
   }
 
   try {
-    const posts = await db.query.blogPosts.findMany({
-      // Exclude soft-deleted posts so retired/consolidated dupes (which
-      // 308-redirect at the detail level) don't still render as index cards.
-      where: and(eq(blogPosts.status, 'PUBLISHED'), isNull(blogPosts.deletedAt)),
-      with: {
-        author: true,
-        category: true,
-        tags: { with: { tag: true } },
-      },
-      orderBy: desc(blogPosts.publishedAt),
-      limit: 50,
-    })
+    const posts = await withDbRetry(() =>
+      db.query.blogPosts.findMany({
+        // Exclude soft-deleted posts so retired/consolidated dupes (which
+        // 308-redirect at the detail level) don't still render as index cards.
+        where: and(eq(blogPosts.status, 'PUBLISHED'), isNull(blogPosts.deletedAt)),
+        with: {
+          author: true,
+          category: true,
+          tags: { with: { tag: true } },
+        },
+        orderBy: desc(blogPosts.publishedAt),
+        limit: 50,
+      })
+    )
 
     return posts.map(transformToBlogPostData)
   } catch (error) {
@@ -94,9 +97,11 @@ const getCategories = cache(async (): Promise<BlogCategoryData[]> => {
   }
 
   try {
-    const categories = await db.query.categories.findMany({
-      orderBy: desc(categoriesTable.totalViews),
-    })
+    const categories = await withDbRetry(() =>
+      db.query.categories.findMany({
+        orderBy: desc(categoriesTable.totalViews),
+      })
+    )
 
     return categories.map((cat) => ({
       id: cat.id,

--- a/src/lib/__tests__/db-retry.test.ts
+++ b/src/lib/__tests__/db-retry.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+import { withDbRetry } from '@/lib/db-retry'
+
+// delaysMs: [] keeps the tests fast + deterministic while still exercising the
+// retry COUNT and propagation behavior.
+const NO_DELAY: number[] = []
+
+describe('withDbRetry', () => {
+  it('returns immediately on first success (no retry)', async () => {
+    const fn = vi.fn().mockResolvedValue('ok')
+    await expect(withDbRetry(fn, 3, NO_DELAY)).resolves.toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('succeeds after transient failures, returning the eventual value', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('neon blip 1'))
+      .mockRejectedValueOnce(new Error('neon blip 2'))
+      .mockResolvedValue('recovered')
+    await expect(withDbRetry(fn, 3, NO_DELAY)).resolves.toBe('recovered')
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+
+  it('re-throws the last error after exhausting all attempts (sustained outage still 500s)', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('neon down'))
+    await expect(withDbRetry(fn, 3, NO_DELAY)).rejects.toThrow('neon down')
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+
+  it('respects a custom attempt count', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('x'))
+    await expect(withDbRetry(fn, 1, NO_DELAY)).rejects.toThrow('x')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('waits between attempts when delays are configured', async () => {
+    vi.useFakeTimers()
+    try {
+      const fn = vi.fn().mockRejectedValueOnce(new Error('blip')).mockResolvedValue('ok')
+      const p = withDbRetry(fn, 3, [50])
+      // First attempt rejects synchronously-ish; advance the backoff timer.
+      await vi.advanceTimersByTimeAsync(50)
+      await expect(p).resolves.toBe('ok')
+      expect(fn).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/lib/db-retry.ts
+++ b/src/lib/db-retry.ts
@@ -1,0 +1,33 @@
+/**
+ * Retry a read on transient failures before letting the error propagate.
+ *
+ * The blog routes are `force-dynamic` and deliberately re-throw DB errors as
+ * HTTP 500 (returning null would trigger notFound() → a soft-404 that the
+ * /blog/* CDN rule caches for 24h). The downside: a single transient neon-http
+ * hiccup during one of the rare crawls Google gives a low-authority site turns
+ * into a 5xx that Search Console penalizes ("Server error (5xx)"). Wrapping the
+ * read in a short retry absorbs those blips; only a sustained outage still 500s,
+ * preserving the no-soft-404 intent.
+ *
+ * Pure/generic — no DB import — so it can wrap any async read and be unit-tested
+ * without a database.
+ */
+export async function withDbRetry<T>(
+  fn: () => Promise<T>,
+  attempts = 3,
+  delaysMs: readonly number[] = [120, 360]
+): Promise<T> {
+  let lastError: unknown
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn()
+    } catch (error) {
+      lastError = error
+      const delay = delaysMs[i]
+      if (delay !== undefined && delay > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delay))
+      }
+    }
+  }
+  throw lastError
+}


### PR DESCRIPTION
The 2nd "Server error (5xx)" page from GSC was `/blog/multi-touch-attribution-modeling-best-practices` — but it's a **live, healthy, ranking page** (returned 200 on 15/15 hammered requests; GSC also said "URL is on Google"). So it's not broken — it **intermittently** 5xx's.

**Root cause (site-wide, not per-post):** the blog routes are `force-dynamic` and `getBlogPost` deliberately **re-throws** DB errors as HTTP 500 (returning `null` would trigger `notFound()` → a soft-404 the `/blog/*` CDN rule caches for 24h). So a single transient `neon-http` hiccup during one of the rare crawls Google gives this low-authority domain becomes a 5xx that Search Console penalizes — a crawlability tax on **every** post.

**Fix:** `withDbRetry` (`src/lib/db-retry.ts`) retries a read up to 3× with short backoff, then re-throws — **preserving the no-soft-404 intent** (a sustained outage still 500s) while absorbing transient blips. Wrapped the force-dynamic blog reads:
- `getBlogPost` + `generateStaticParams` (`/blog/[slug]`)
- `getBlogPosts` + `getCategories` (`/blog` index)

**Tests (+5):** first-try success (no retry), recovery after transient failures, re-throw after exhausting attempts (outage still 500s), custom attempt count, backoff timing (fake timers).

**Verification:** typecheck ✓ · biome ✓ · vitest **1060** ✓ · build ✓

[hudsor01]