### PR TITLE
seo: drop the cascading site-wide canonical (duplicate-content footgun)

### DIFF
--- a/src/app/shared-metadata.ts
+++ b/src/app/shared-metadata.ts
@@ -76,9 +76,11 @@ export const baseMetadata: Metadata = {
       'max-snippet': -1,
     },
   },
-  alternates: {
-    canonical: SITE_ORIGIN,
-  },
+  // No site-wide `alternates.canonical` here on purpose. A cascading canonical
+  // in root metadata makes any page that omits its own canonical silently point
+  // at the homepage — a duplicate-content footgun (it's exactly what made every
+  // page on the sister site canonicalize to its homepage). Every route sets its
+  // own canonical; a page without one correctly self-canonicalizes via Google.
   verification: {
     google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION || '',
   },


### PR DESCRIPTION
Prompted by the sister site (hudsondigitalsolutions.com) PR #314, where a root-layout canonical cascaded into every page → all pages declared themselves duplicates of the homepage. I checked modern-portfolio for the same defect.

**Good news — no live bug:** `baseMetadata` set `alternates.canonical = SITE_ORIGIN`, but an audit of **all 30 routes** found every one sets its own canonical (verified live: `/`, `/about`, `/resume`, `/projects/[slug]` all self-canonicalize). So nothing is currently mis-canonicalizing.

**But it's a footgun:** the cascading default means the *next* page added that forgets its own canonical would silently canonicalize to the homepage — exactly what bit the sister site. This removes the default (the homepage self-canonicalizes via its own `page.tsx`) and documents *why*, so it can't be re-introduced. Pages without an explicit canonical now correctly let Google self-canonicalize instead of pointing at the homepage.

**Zero live impact** (every page already overrides it) — purely defensive.

**Verification:** typecheck ✓ · biome ✓ · vitest **1060** ✓ · build ✓ (clean rebuild). No live canonical changes.

[hudsor01]