### PR TITLE
feat(tools): RevOps Maturity Scorecard (ungated linkable asset)

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -95,6 +95,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'monthly',
       priority: 0.8,
     },
+    {
+      url: `${baseUrl}/tools/revops-maturity-scorecard`,
+      lastModified: staticLastModified,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
   ]
 
   // All project pages (complete list).

--- a/src/app/tools/revops-maturity-scorecard/_components/revops-maturity-scorecard.tsx
+++ b/src/app/tools/revops-maturity-scorecard/_components/revops-maturity-scorecard.tsx
@@ -1,0 +1,184 @@
+'use client'
+
+import { useId, useMemo, useState } from 'react'
+import {
+  PILLARS,
+  QUESTIONS,
+  scoreMaturity,
+  tierForScore,
+  type PillarId,
+} from '@/lib/revops-maturity'
+
+const SCALE = [
+  { value: 1, label: 'Not at all' },
+  { value: 2, label: 'Rarely' },
+  { value: 3, label: 'Somewhat' },
+  { value: 4, label: 'Mostly' },
+  { value: 5, label: 'Fully' },
+] as const
+
+const DEFAULT = 3
+
+/** Pillar score (1–5) → bar fill class. Weakest pillars read warmer. */
+function barColor(score: number): string {
+  if (score < 2.6) return 'bg-destructive'
+  if (score < 3.4) return 'bg-amber-500'
+  return 'bg-success'
+}
+
+export function RevOpsMaturityScorecard() {
+  const groupName = useId()
+  const [answers, setAnswers] = useState<Record<string, number>>(() =>
+    Object.fromEntries(QUESTIONS.map((q) => [q.id, DEFAULT]))
+  )
+
+  const result = useMemo(() => scoreMaturity(answers), [answers])
+  const tier = tierForScore(result.overallScore)
+
+  const setAnswer = (id: string, value: number) => setAnswers((prev) => ({ ...prev, [id]: value }))
+
+  const reset = () => setAnswers(Object.fromEntries(QUESTIONS.map((q) => [q.id, DEFAULT])))
+
+  return (
+    <div className="grid gap-8 lg:grid-cols-5">
+      {/* Questions */}
+      <div className="lg:col-span-3 space-y-8">
+        {PILLARS.map((pillar) => (
+          <fieldset
+            key={pillar.id}
+            className="bg-card rounded-2xl p-6 sm:p-8 border border-border shadow-sm"
+          >
+            <legend className="px-1">
+              <span className="block font-display text-xl font-semibold text-foreground">
+                {pillar.label}
+              </span>
+              <span className="block text-sm text-muted-foreground mt-0.5">{pillar.blurb}</span>
+            </legend>
+
+            <div className="mt-6 space-y-6">
+              {QUESTIONS.filter((q) => q.pillar === pillar.id).map((q) => (
+                <div key={q.id}>
+                  <p id={`${groupName}-${q.id}-label`} className="text-sm text-foreground mb-2.5">
+                    {q.text}
+                  </p>
+                  <div
+                    role="radiogroup"
+                    aria-labelledby={`${groupName}-${q.id}-label`}
+                    className="grid grid-cols-5 gap-1.5"
+                  >
+                    {SCALE.map((opt) => {
+                      const selected = answers[q.id] === opt.value
+                      return (
+                        <label
+                          key={opt.value}
+                          className={`flex flex-col items-center justify-center rounded-lg border px-1 py-2 cursor-pointer text-center transition-colors ${
+                            selected
+                              ? 'border-primary bg-primary/10 text-primary'
+                              : 'border-border bg-background text-muted-foreground hover:border-primary/50'
+                          }`}
+                        >
+                          <input
+                            type="radio"
+                            name={`${groupName}-${q.id}`}
+                            value={opt.value}
+                            checked={selected}
+                            onChange={() => setAnswer(q.id, opt.value)}
+                            className="sr-only"
+                          />
+                          <span className="text-base font-semibold leading-none">{opt.value}</span>
+                          <span className="mt-1 text-[10px] leading-tight">{opt.label}</span>
+                        </label>
+                      )
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </fieldset>
+        ))}
+
+        <button
+          type="button"
+          onClick={reset}
+          className="text-sm text-muted-foreground hover:text-primary transition-colors underline underline-offset-4"
+        >
+          Reset all to neutral
+        </button>
+      </div>
+
+      {/* Results */}
+      <div className="lg:col-span-2">
+        <div
+          className="lg:sticky lg:top-28 bg-card rounded-2xl p-6 sm:p-8 border border-border shadow-sm"
+          aria-live="polite"
+        >
+          <p className="text-sm uppercase tracking-wider text-muted-foreground">
+            Your maturity level
+          </p>
+          <p className="mt-1 flex items-baseline gap-2">
+            <span className="text-5xl font-bold text-primary tracking-tight">{result.level}</span>
+            <span className="text-2xl font-semibold text-foreground">{result.tier}</span>
+          </p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Overall score {result.overallScore.toFixed(1)} / 5 · ~{result.percentile}th percentile
+            of B2B teams
+          </p>
+          {tier && <p className="mt-3 text-sm text-foreground leading-relaxed">{tier.blurb}</p>}
+
+          {/* Per-pillar bars */}
+          <div className="mt-6 space-y-3">
+            {PILLARS.map((pillar) => {
+              const score = result.pillarScores[pillar.id as PillarId]
+              const isWeakest = result.weakestPillar === pillar.id
+              return (
+                <div key={pillar.id}>
+                  <div className="flex items-center justify-between text-sm">
+                    <span
+                      className={isWeakest ? 'font-semibold text-foreground' : 'text-foreground'}
+                    >
+                      {pillar.label}
+                      {isWeakest && (
+                        <span className="ml-2 text-[10px] uppercase tracking-wide text-destructive">
+                          weakest
+                        </span>
+                      )}
+                    </span>
+                    <span className="tabular-nums text-muted-foreground">{score.toFixed(1)}</span>
+                  </div>
+                  <div className="mt-1 h-2 w-full rounded-full bg-muted overflow-hidden">
+                    <div
+                      className={`h-full rounded-full transition-all ${barColor(score)}`}
+                      style={{ width: `${(Math.min(5, Math.max(0, score)) / 5) * 100}%` }}
+                    />
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+
+          {/* Highest-ROI next move */}
+          {result.nextMove && (
+            <div className="mt-6 rounded-xl bg-muted/50 p-4">
+              <p className="text-xs uppercase tracking-wider text-muted-foreground mb-1">
+                Highest-ROI next move
+              </p>
+              <p className="text-sm text-foreground leading-relaxed">{result.nextMove}</p>
+            </div>
+          )}
+
+          {/* Tech-overbuy anti-pattern */}
+          {result.techOverbuy && (
+            <div className="mt-4 rounded-xl border border-destructive/40 bg-destructive/5 p-4">
+              <p className="text-sm text-foreground leading-relaxed">
+                <strong className="text-destructive">Watch out:</strong> your tooling maturity is
+                running ahead of your data and process maturity — the classic{' '}
+                <em>buying tools you can’t feed</em> trap. Fix the foundation before adding more
+                stack, or the new tools inherit the same messy inputs.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/tools/revops-maturity-scorecard/page.tsx
+++ b/src/app/tools/revops-maturity-scorecard/page.tsx
@@ -1,0 +1,194 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { Navbar } from '@/components/layout/navbar'
+import { FAQPageJsonLd } from '@/components/seo/json-ld/faq-json-ld'
+import { BreadcrumbListJsonLd } from '@/components/seo/json-ld/breadcrumb-json-ld'
+import { canonicalUrl, SITE_ORIGIN } from '@/lib/absolute-url'
+import { RevOpsMaturityScorecard } from './_components/revops-maturity-scorecard'
+
+const PATH = '/tools/revops-maturity-scorecard'
+const TITLE = 'RevOps Maturity Scorecard — Score Your Revenue Operations (Free, No Email)'
+const DESCRIPTION =
+  'Free RevOps maturity assessment. Score your revenue operations across process, data, technology, and alignment in two minutes — get your maturity level, percentile, and the single highest-ROI next move. No email required.'
+
+const OG_IMAGE = canonicalUrl(
+  `/api/og?${new URLSearchParams({
+    title: 'RevOps Maturity Scorecard',
+    subtitle: 'Score your revenue operations in 2 minutes',
+  }).toString()}`
+)
+
+const FAQS: Array<{ question: string; answer: string }> = [
+  {
+    question: 'What is RevOps maturity?',
+    answer:
+      'RevOps maturity is how systematic and repeatable your revenue engine is across four pillars: process (documented, followed motions), data (clean and trusted), technology (an integrated, right-sized stack), and alignment (Sales, Marketing, and CS on one number). Higher maturity means more predictable revenue and less reliance on heroics.',
+  },
+  {
+    question: 'What are the levels of revenue operations maturity?',
+    answer:
+      'This scorecard uses five levels: 1 Ad-hoc (heroics and spreadsheets), 2 Emerging (inconsistent process), 3 Defined (documented and mostly followed), 4 Managed (process, data, and tools reinforce each other), and 5 Optimized (a strategic, automated, aligned engine). Most B2B teams land between Emerging and Defined.',
+  },
+  {
+    question: 'How do I assess my RevOps maturity?',
+    answer:
+      'Rate your team honestly on 16 statements across the four pillars. The scorecard averages each pillar, rolls them into an overall level, shows your weakest pillar, and gives you the single highest-ROI next move. It takes about two minutes and requires no email.',
+  },
+  {
+    question: 'What is the most common RevOps maturity mistake?',
+    answer:
+      'Buying technology that is more mature than your data and process can support — automating a broken process just produces broken outputs faster, and AI or attribution tools inherit whatever quality your CRM data already has. The scorecard flags this "tools you can\'t feed" gap when your technology score outruns your data or process score.',
+  },
+  {
+    question: 'What is the average RevOps maturity level?',
+    answer:
+      'Published B2B benchmarks put the median team around level 2.4 of 5 — Emerging to Defined — and only roughly 7% of teams operate at level 5. Your percentile in the scorecard is a directional estimate against those benchmarks, not an audited sample.',
+  },
+  {
+    question: 'Why is the scorecard free with no email gate?',
+    answer:
+      'A maturity score is only useful if you can act on it immediately. Gating the result behind a form adds friction and tempts inflated benchmarks. This one runs entirely in your browser, shows your result instantly, and never asks for an email.',
+  },
+]
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  keywords: [
+    'revops maturity',
+    'revops maturity model',
+    'revops maturity assessment',
+    'revenue operations maturity model',
+    'revenue operations maturity assessment',
+    'revops maturity scorecard',
+    'how mature is my revops',
+  ],
+  alternates: { canonical: canonicalUrl(PATH) },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: canonicalUrl(PATH),
+    type: 'website',
+    images: [{ url: OG_IMAGE, width: 1200, height: 630, alt: 'RevOps Maturity Scorecard' }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    creator: '@hudsor01',
+    title: TITLE,
+    description: DESCRIPTION,
+    images: [OG_IMAGE],
+  },
+}
+
+export default function RevOpsMaturityScorecardPage() {
+  return (
+    <>
+      <BreadcrumbListJsonLd
+        items={[
+          { name: 'Home', url: SITE_ORIGIN },
+          { name: 'RevOps Maturity Scorecard', url: canonicalUrl(PATH) },
+        ]}
+      />
+      <FAQPageJsonLd faqs={FAQS} />
+
+      <div className="min-h-screen bg-background">
+        <Navbar />
+        <main id="main-content" className="max-w-6xl mx-auto px-6 lg:px-8 pt-24 pb-20 lg:pt-32">
+          <header className="mb-10 max-w-3xl">
+            <p className="text-sm text-muted-foreground mb-3">
+              <Link href="/" className="hover:text-primary">
+                Home
+              </Link>{' '}
+              / RevOps Maturity Scorecard
+            </p>
+            <h1 className="font-display text-4xl md:text-5xl font-bold text-foreground tracking-tight mb-4">
+              RevOps Maturity Scorecard
+            </h1>
+            <p className="text-lg text-muted-foreground leading-relaxed">
+              Where does your revenue engine actually stand? Rate your team across the four pillars
+              that drive RevOps maturity — <strong>process, data, technology, and alignment</strong>{' '}
+              — and get your maturity level, your percentile, and the single highest-ROI move to
+              make next. Two minutes, no email.
+            </p>
+          </header>
+
+          <RevOpsMaturityScorecard />
+
+          <section className="mt-16 max-w-3xl">
+            <h2 className="text-2xl font-semibold text-foreground mb-4">
+              Why your weakest pillar is your ceiling
+            </h2>
+            <div className="space-y-4 text-muted-foreground leading-relaxed">
+              <p>
+                RevOps maturity isn’t an average you can buy your way out of — it’s gated by your
+                weakest pillar. A best-in-class tech stack sitting on dirty CRM data produces
+                confident, automated, wrong answers. That’s why the scorecard points you at the
+                lowest-scoring pillar instead of the one that’s most fun to improve.
+              </p>
+              <p>
+                The most expensive mistake is buying <strong>technology</strong> more mature than
+                your <strong>data</strong> and <strong>process</strong> can support. Automating a
+                broken process just makes broken outputs faster; AI and attribution tools inherit
+                whatever quality your data already has. The scorecard flags this “tools you can’t
+                feed” gap when it sees it.
+              </p>
+              <p>
+                The honest order of operations is almost always the same: document the process,
+                clean the data, then let technology automate what’s now repeatable — with alignment
+                making sure every team is optimizing the same revenue number.
+              </p>
+            </div>
+          </section>
+
+          <section className="mt-12 max-w-3xl">
+            <h2 className="text-2xl font-semibold text-foreground mb-6">
+              Frequently asked questions
+            </h2>
+            <dl className="space-y-6">
+              {FAQS.map((faq) => (
+                <div key={faq.question}>
+                  <dt className="font-semibold text-foreground">{faq.question}</dt>
+                  <dd className="mt-1 text-muted-foreground leading-relaxed">{faq.answer}</dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+
+          <section className="mt-12 pt-8 border-t border-border max-w-3xl">
+            <h2 className="text-xl font-semibold text-foreground mb-4">
+              Related reading &amp; tools
+            </h2>
+            <ul className="space-y-2 text-primary">
+              <li>
+                <Link href="/tools/pipeline-coverage-calculator" className="hover:underline">
+                  Pipeline Coverage Calculator — how much pipeline you really need
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/blog/complete-guide-revenue-operations-strategy"
+                  className="hover:underline"
+                >
+                  The complete guide to revenue operations strategy
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/blog/stop-guessing-how-we-slashed-forecast-variance-by-34-in-90-days"
+                  className="hover:underline"
+                >
+                  How we slashed forecast variance by 34% in 90 days
+                </Link>
+              </li>
+              <li>
+                <Link href="/projects/revenue-operations-center" className="hover:underline">
+                  Case study: Revenue Operations Command Center
+                </Link>
+              </li>
+            </ul>
+          </section>
+        </main>
+      </div>
+    </>
+  )
+}

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -24,6 +24,7 @@ const FOOTER_SECTIONS: ReadonlyArray<{
       { label: 'All articles', href: '/blog' },
       { label: 'RevOps insights', href: '/blog/category/revenue-operations' },
       { label: 'Pipeline coverage calculator', href: '/tools/pipeline-coverage-calculator' },
+      { label: 'RevOps maturity scorecard', href: '/tools/revops-maturity-scorecard' },
     ],
   },
   {

--- a/src/lib/__tests__/revops-maturity.test.ts
+++ b/src/lib/__tests__/revops-maturity.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest'
+import {
+  scoreMaturity,
+  levelForScore,
+  tierForScore,
+  QUESTIONS,
+  PILLARS,
+  TIERS,
+  type PillarId,
+} from '@/lib/revops-maturity'
+
+/** Build an answer map setting every question to `v`. */
+function allAt(v: number): Record<string, number> {
+  return Object.fromEntries(QUESTIONS.map((q) => [q.id, v]))
+}
+
+/** Build an answer map with a per-pillar value. */
+function byPillar(values: Record<PillarId, number>): Record<string, number> {
+  return Object.fromEntries(QUESTIONS.map((q) => [q.id, values[q.pillar]]))
+}
+
+describe('scoreMaturity — overall scoring', () => {
+  it('all 1s → level 1 Ad-hoc, score 1, valid', () => {
+    const r = scoreMaturity(allAt(1))
+    expect(r.valid).toBe(true)
+    expect(r.answered).toBe(QUESTIONS.length)
+    expect(r.overallScore).toBeCloseTo(1, 6)
+    expect(r.level).toBe(1)
+    expect(r.tier).toBe('Ad-hoc')
+  })
+
+  it('all 5s → level 5 Optimized, score 5', () => {
+    const r = scoreMaturity(allAt(5))
+    expect(r.overallScore).toBeCloseTo(5, 6)
+    expect(r.level).toBe(5)
+    expect(r.tier).toBe('Optimized')
+    expect(r.percentile).toBe(97)
+  })
+
+  it('all 3s → level 3 Defined', () => {
+    const r = scoreMaturity(allAt(3))
+    expect(r.overallScore).toBeCloseTo(3, 6)
+    expect(r.level).toBe(3)
+    expect(r.tier).toBe('Defined')
+  })
+
+  it('per-pillar means roll up to the overall mean', () => {
+    const r = scoreMaturity(byPillar({ process: 4, data: 2, technology: 3, alignment: 1 }))
+    expect(r.pillarScores.process).toBeCloseTo(4, 6)
+    expect(r.pillarScores.data).toBeCloseTo(2, 6)
+    expect(r.pillarScores.technology).toBeCloseTo(3, 6)
+    expect(r.pillarScores.alignment).toBeCloseTo(1, 6)
+    expect(r.overallScore).toBeCloseTo((4 + 2 + 3 + 1) / 4, 6) // 2.5
+    expect(r.level).toBe(2) // 2.5 < 2.6 → Emerging
+  })
+})
+
+describe('scoreMaturity — weakest pillar (highest-ROI next move)', () => {
+  it('identifies the single lowest-scoring pillar', () => {
+    const r = scoreMaturity(byPillar({ process: 4, data: 2, technology: 5, alignment: 3 }))
+    expect(r.weakestPillar).toBe('data')
+    expect(r.nextMove).toMatch(/CRM hygiene|definitions/i)
+  })
+
+  it('ties resolve to canonical pillar order (process first)', () => {
+    const r = scoreMaturity(byPillar({ process: 2, data: 2, technology: 5, alignment: 5 }))
+    expect(r.weakestPillar).toBe('process')
+  })
+
+  it('alignment can be the weakest link', () => {
+    const r = scoreMaturity(byPillar({ process: 5, data: 5, technology: 5, alignment: 1 }))
+    expect(r.weakestPillar).toBe('alignment')
+    expect(r.nextMove).toMatch(/Sales, Marketing/i)
+  })
+})
+
+describe('scoreMaturity — tech-overbuy anti-pattern', () => {
+  it('flags tech running a full level ahead of data/process', () => {
+    const r = scoreMaturity(byPillar({ process: 2, data: 2, technology: 4, alignment: 3 }))
+    expect(r.techOverbuy).toBe(true) // 4 - min(2,2) = 2 ≥ 1
+  })
+
+  it('does not flag when tech is in line with the foundation', () => {
+    const r = scoreMaturity(byPillar({ process: 4, data: 4, technology: 4, alignment: 4 }))
+    expect(r.techOverbuy).toBe(false)
+  })
+
+  it('does not flag when data/process exceed tech (healthy direction)', () => {
+    const r = scoreMaturity(byPillar({ process: 5, data: 5, technology: 3, alignment: 4 }))
+    expect(r.techOverbuy).toBe(false)
+  })
+
+  it('uses the WEAKER of data/process as the foundation', () => {
+    // data high, process low → still overbuying relative to process
+    const r = scoreMaturity(byPillar({ process: 2, data: 5, technology: 4, alignment: 3 }))
+    expect(r.techOverbuy).toBe(true) // 4 - min(5,2)=2 ≥ 1
+  })
+})
+
+describe('scoreMaturity — partial / adversarial input', () => {
+  it('empty answers → not valid, zeroed, no weakest pillar', () => {
+    const r = scoreMaturity({})
+    expect(r.valid).toBe(false)
+    expect(r.answered).toBe(0)
+    expect(r.overallScore).toBe(0)
+    expect(r.level).toBe(0)
+    expect(r.tier).toBe('')
+    expect(r.weakestPillar).toBeNull()
+    expect(r.nextMove).toBe('')
+    expect(r.percentile).toBe(0)
+    expect(r.techOverbuy).toBe(false)
+  })
+
+  it('partial answers → not valid, but scores only the answered pillars', () => {
+    // Only the process pillar answered (4 questions), all at 5.
+    const answers = Object.fromEntries(
+      QUESTIONS.filter((q) => q.pillar === 'process').map((q) => [q.id, 5])
+    )
+    const r = scoreMaturity(answers)
+    expect(r.valid).toBe(false)
+    expect(r.answered).toBe(4)
+    expect(r.pillarScores.process).toBeCloseTo(5, 6)
+    expect(r.pillarScores.data).toBe(0)
+    expect(r.overallScore).toBeCloseTo(5, 6) // empty pillars excluded, not averaged as 0
+    expect(r.weakestPillar).toBe('process')
+    expect(r.techOverbuy).toBe(false) // needs tech+data+process all answered
+  })
+
+  it('clamps out-of-range numeric answers into [1,5]', () => {
+    const r = scoreMaturity(allAt(99))
+    expect(r.overallScore).toBeCloseTo(5, 6)
+    const r0 = scoreMaturity(allAt(-10))
+    expect(r0.overallScore).toBeCloseTo(1, 6)
+  })
+
+  it('ignores NaN / Infinity / non-number answers as unanswered', () => {
+    const answers: Record<string, number> = allAt(4)
+    answers.p1 = Number.NaN
+    answers.d1 = Number.POSITIVE_INFINITY
+    // @ts-expect-error — guarding against bad runtime input
+    answers.t1 = 'four'
+    const r = scoreMaturity(answers)
+    expect(r.valid).toBe(false) // 3 questions dropped
+    expect(r.answered).toBe(QUESTIONS.length - 3)
+    // remaining process questions (p2-p4) still all 4
+    expect(r.pillarScores.process).toBeCloseTo(4, 6)
+  })
+})
+
+describe('levelForScore / tierForScore — band boundaries', () => {
+  it('maps band edges to the right level', () => {
+    expect(levelForScore(1.0)).toBe(1)
+    expect(levelForScore(1.79)).toBe(1)
+    expect(levelForScore(1.8)).toBe(2) // exclusive upper bound
+    expect(levelForScore(2.59)).toBe(2)
+    expect(levelForScore(2.6)).toBe(3)
+    expect(levelForScore(3.39)).toBe(3)
+    expect(levelForScore(3.4)).toBe(4)
+    expect(levelForScore(4.19)).toBe(4)
+    expect(levelForScore(4.2)).toBe(5)
+    expect(levelForScore(5.0)).toBe(5)
+  })
+
+  it('returns 0 for non-positive / non-finite scores', () => {
+    expect(levelForScore(0)).toBe(0)
+    expect(levelForScore(-1)).toBe(0)
+    expect(levelForScore(Number.NaN)).toBe(0)
+  })
+
+  it('tierForScore returns the matching tier object', () => {
+    expect(tierForScore(2.4)?.label).toBe('Emerging')
+    expect(tierForScore(5)?.label).toBe('Optimized')
+  })
+})
+
+describe('percentile — directional benchmark', () => {
+  it('median (2.4) ≈ 50th percentile', () => {
+    const r = scoreMaturity(allAt(2.4))
+    expect(r.percentile).toBe(50)
+  })
+
+  it('monotonically increases with score', () => {
+    const p1 = scoreMaturity(allAt(1)).percentile
+    const p3 = scoreMaturity(allAt(3)).percentile
+    const p5 = scoreMaturity(allAt(5)).percentile
+    expect(p1).toBeLessThan(p3)
+    expect(p3).toBeLessThan(p5)
+    expect(p1).toBeGreaterThanOrEqual(1)
+    expect(p5).toBeLessThanOrEqual(99)
+  })
+})
+
+describe('data integrity', () => {
+  it('has 4 pillars and 16 questions, 4 per pillar', () => {
+    expect(PILLARS).toHaveLength(4)
+    expect(QUESTIONS).toHaveLength(16)
+    for (const p of PILLARS) {
+      expect(QUESTIONS.filter((q) => q.pillar === p.id)).toHaveLength(4)
+    }
+  })
+
+  it('question ids are unique', () => {
+    const ids = QUESTIONS.map((q) => q.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('tiers are contiguous and ordered with an Infinity top band', () => {
+    expect(TIERS).toHaveLength(5)
+    expect(TIERS.map((t) => t.level)).toEqual([1, 2, 3, 4, 5])
+    expect(TIERS[TIERS.length - 1]!.max).toBe(Number.POSITIVE_INFINITY)
+  })
+})

--- a/src/lib/revops-maturity.ts
+++ b/src/lib/revops-maturity.ts
@@ -1,0 +1,354 @@
+/**
+ * Revenue Operations maturity scoring.
+ *
+ * A self-assessment across the four pillars that actually move RevOps maturity —
+ * Process, Data, Technology, and Alignment — scored on a 1–5 scale per pillar and
+ * rolled up to an overall maturity level (1 Ad-hoc → 5 Optimized). This is the
+ * pure, side-effect-free core behind the RevOps Maturity Scorecard so it can be
+ * unit-tested to the edges independent of the UI.
+ *
+ * Two opinions are baked in, both grounded in how RevOps maturity actually fails:
+ *  1. Your weakest pillar is your ceiling — the highest-ROI next move is always
+ *     the lowest-scoring pillar, not the one you most enjoy improving.
+ *  2. Tooling maturity that runs ahead of data/process maturity is an
+ *     anti-pattern ("buying tools you can't feed"), so we flag it explicitly.
+ *
+ * No Date/Math.random — fully deterministic for the same answers.
+ */
+
+export type PillarId = 'process' | 'data' | 'technology' | 'alignment'
+
+export interface Pillar {
+  id: PillarId
+  label: string
+  /** One-line description of what the pillar measures. */
+  blurb: string
+}
+
+export interface Question {
+  id: string
+  pillar: PillarId
+  /** A maturity statement the respondent rates 1 (not at all) → 5 (fully). */
+  text: string
+}
+
+export interface Tier {
+  level: number
+  label: string
+  /** Exclusive upper bound of the overall-score band; the top tier uses Infinity. */
+  max: number
+  blurb: string
+}
+
+export interface MaturityResult {
+  /** True only when every question has a valid 1–5 answer. */
+  valid: boolean
+  answered: number
+  total: number
+  /** Mean 1–5 score per pillar; 0 for a pillar with no valid answers. */
+  pillarScores: Record<PillarId, number>
+  /** Mean of the pillars that have at least one answer; 0 if nothing answered. */
+  overallScore: number
+  /** Maturity level 1–5 derived from `overallScore` (0 if nothing answered). */
+  level: number
+  /** Human label for `level` ('Ad-hoc' … 'Optimized'); '' if nothing answered. */
+  tier: string
+  /** Lowest-scoring answered pillar — the highest-ROI place to invest next. */
+  weakestPillar: PillarId | null
+  /** The recommended next move, derived from `weakestPillar`. */
+  nextMove: string
+  /**
+   * True when tooling maturity runs ≥1 full level ahead of the weaker of
+   * data/process maturity — the "buying tools you can't feed" anti-pattern.
+   */
+  techOverbuy: boolean
+  /** Directional percentile vs published B2B RevOps maturity benchmarks (1–99). */
+  percentile: number
+}
+
+export const PILLARS: readonly Pillar[] = [
+  {
+    id: 'process',
+    label: 'Process',
+    blurb: 'Documented, repeatable revenue motions — stages, handoffs, forecasting.',
+  },
+  {
+    id: 'data',
+    label: 'Data',
+    blurb: 'Clean, trusted, standardized data and a single source of truth.',
+  },
+  {
+    id: 'technology',
+    label: 'Technology',
+    blurb: 'An integrated, right-sized stack that automates instead of adding friction.',
+  },
+  {
+    id: 'alignment',
+    label: 'Alignment',
+    blurb: 'Sales, Marketing, and CS sharing goals, metrics, and a single revenue number.',
+  },
+] as const
+
+export const QUESTIONS: readonly Question[] = [
+  // Process
+  {
+    id: 'p1',
+    pillar: 'process',
+    text: 'Our sales stages have documented entry/exit criteria that reps actually follow.',
+  },
+  {
+    id: 'p2',
+    pillar: 'process',
+    text: 'Lead routing and handoffs (MQL → SDR → AE → CS) are defined and enforced.',
+  },
+  {
+    id: 'p3',
+    pillar: 'process',
+    text: 'We run a consistent forecast cadence with a repeatable methodology.',
+  },
+  {
+    id: 'p4',
+    pillar: 'process',
+    text: 'Core revenue processes are documented, not tribal knowledge in a few heads.',
+  },
+  // Data
+  {
+    id: 'd1',
+    pillar: 'data',
+    text: 'Our CRM data is clean, deduplicated, and trusted for decisions.',
+  },
+  {
+    id: 'd2',
+    pillar: 'data',
+    text: 'Key definitions (MQL, SQL, pipeline, ARR) are standardized across teams.',
+  },
+  {
+    id: 'd3',
+    pillar: 'data',
+    text: 'We can attribute revenue to source and channel with confidence.',
+  },
+  {
+    id: 'd4',
+    pillar: 'data',
+    text: 'Reporting comes from a single source of truth, not conflicting spreadsheets.',
+  },
+  // Technology
+  {
+    id: 't1',
+    pillar: 'technology',
+    text: 'Our GTM tools are integrated and data flows between them automatically.',
+  },
+  {
+    id: 't2',
+    pillar: 'technology',
+    text: "We've eliminated redundant or overlapping tools and shadow systems.",
+  },
+  {
+    id: 't3',
+    pillar: 'technology',
+    text: 'Reps spend minimal time on manual data entry and admin.',
+  },
+  {
+    id: 't4',
+    pillar: 'technology',
+    text: 'We adopt new tools based on a real need and maturity fit, not hype.',
+  },
+  // Alignment
+  {
+    id: 'a1',
+    pillar: 'alignment',
+    text: 'Sales, Marketing, and CS share goals and a single revenue number.',
+  },
+  {
+    id: 'a2',
+    pillar: 'alignment',
+    text: 'There is a clear owner (a RevOps function) for cross-team process and data.',
+  },
+  {
+    id: 'a3',
+    pillar: 'alignment',
+    text: 'Comp plans reinforce the behaviors leadership actually wants.',
+  },
+  {
+    id: 'a4',
+    pillar: 'alignment',
+    text: 'Leadership decisions run on the same metrics RevOps reports.',
+  },
+] as const
+
+export const TIERS: readonly Tier[] = [
+  {
+    level: 1,
+    label: 'Ad-hoc',
+    max: 1.8,
+    blurb:
+      'Revenue runs on heroics and spreadsheets. Outcomes are unpredictable because the process is improvised every quarter.',
+  },
+  {
+    level: 2,
+    label: 'Emerging',
+    max: 2.6,
+    blurb:
+      'Some process exists but it is inconsistent. Data and tools are partial, and teams still argue about the numbers.',
+  },
+  {
+    level: 3,
+    label: 'Defined',
+    max: 3.4,
+    blurb:
+      'Core motions are documented and mostly followed. You have a working source of truth — now the gains come from consistency and integration.',
+  },
+  {
+    level: 4,
+    label: 'Managed',
+    max: 4.2,
+    blurb:
+      'Process, data, and tools reinforce each other. You measure what matters and act on it — the focus shifts to optimization and prediction.',
+  },
+  {
+    level: 5,
+    label: 'Optimized',
+    max: Number.POSITIVE_INFINITY,
+    blurb:
+      'RevOps is a strategic engine: clean data, automated workflows, aligned teams, and forecasting you trust. Fewer than ~1 in 10 teams operate here.',
+  },
+] as const
+
+/** The highest-ROI next move for each pillar when it is the weakest link. */
+const NEXT_MOVE: Record<PillarId, string> = {
+  process:
+    'Document your sales stages with explicit entry/exit criteria and lock in one forecast methodology — process gaps compound into every report and tool downstream. Fix this before you buy anything.',
+  data: 'Clean up CRM hygiene and standardize your core definitions (MQL, SQL, pipeline, ARR) first. Every dashboard, attribution model, and AI feature you add inherits the quality of this data.',
+  technology:
+    'Consolidate overlapping tools and automate the manual handoffs eating your reps’ time — the highest return is removing friction from the stack you already own, not adding to it.',
+  alignment:
+    'Get Sales, Marketing, and CS onto one shared revenue number with a single owner for cross-team process. Misalignment quietly caps the return on every other improvement you make.',
+}
+
+/** Gap (in pillar levels) at which tech maturity outrunning data/process is flagged. */
+const TECH_OVERBUY_GAP = 1.0
+
+/**
+ * Directional percentile anchors. Grounded in published B2B RevOps maturity
+ * studies that put the median team around level 2.4/5 and only ~7% at level 5.
+ * Monotonic; linearly interpolated between anchors. This is a positioning
+ * estimate, not an audited sample — the UI labels it as such.
+ */
+const PERCENTILE_ANCHORS: ReadonlyArray<readonly [score: number, pct: number]> = [
+  [1.0, 5],
+  [2.0, 35],
+  [2.4, 50],
+  [3.0, 65],
+  [3.4, 75],
+  [4.0, 86],
+  [4.5, 93],
+  [5.0, 97],
+]
+
+function clampAnswer(v: number | undefined): number | undefined {
+  if (typeof v !== 'number' || !Number.isFinite(v)) return undefined
+  return Math.min(5, Math.max(1, v))
+}
+
+export function levelForScore(score: number): number {
+  if (!Number.isFinite(score) || score <= 0) return 0
+  for (const tier of TIERS) {
+    if (score < tier.max) return tier.level
+  }
+  return TIERS[TIERS.length - 1]!.level
+}
+
+export function tierForScore(score: number): Tier | null {
+  const level = levelForScore(score)
+  return TIERS.find((t) => t.level === level) ?? null
+}
+
+function percentileForScore(score: number): number {
+  if (!Number.isFinite(score) || score <= 0) return 0
+  const first = PERCENTILE_ANCHORS[0]!
+  const last = PERCENTILE_ANCHORS[PERCENTILE_ANCHORS.length - 1]!
+  if (score <= first[0]) return first[1]
+  if (score >= last[0]) return last[1]
+  for (let i = 0; i < PERCENTILE_ANCHORS.length - 1; i++) {
+    const [lowScore, lowPct] = PERCENTILE_ANCHORS[i]!
+    const [highScore, highPct] = PERCENTILE_ANCHORS[i + 1]!
+    if (score <= highScore) {
+      const t = (score - lowScore) / (highScore - lowScore)
+      return Math.round(lowPct + t * (highPct - lowPct))
+    }
+  }
+  return last[1]
+}
+
+export function scoreMaturity(answers: Partial<Record<string, number>>): MaturityResult {
+  const total = QUESTIONS.length
+
+  // Group valid answers by pillar.
+  const byPillar: Record<PillarId, number[]> = {
+    process: [],
+    data: [],
+    technology: [],
+    alignment: [],
+  }
+  let answered = 0
+  for (const q of QUESTIONS) {
+    const v = clampAnswer(answers[q.id])
+    if (v !== undefined) {
+      byPillar[q.pillar].push(v)
+      answered++
+    }
+  }
+
+  const mean = (xs: number[]): number =>
+    xs.length === 0 ? 0 : xs.reduce((sum, x) => sum + x, 0) / xs.length
+
+  const pillarScores: Record<PillarId, number> = {
+    process: mean(byPillar.process),
+    data: mean(byPillar.data),
+    technology: mean(byPillar.technology),
+    alignment: mean(byPillar.alignment),
+  }
+
+  // Overall = mean of pillars that actually have answers (so a partially
+  // completed assessment isn't dragged down by empty pillars scored 0).
+  const scored = PILLARS.map((p) => pillarScores[p.id]).filter((s) => s > 0)
+  const overallScore = scored.length === 0 ? 0 : scored.reduce((a, b) => a + b, 0) / scored.length
+
+  // Weakest answered pillar (ties resolve to canonical pillar order).
+  let weakestPillar: PillarId | null = null
+  let weakestScore = Number.POSITIVE_INFINITY
+  for (const p of PILLARS) {
+    const s = pillarScores[p.id]
+    if (byPillar[p.id].length > 0 && s < weakestScore) {
+      weakestScore = s
+      weakestPillar = p.id
+    }
+  }
+
+  // Anti-pattern: tech running ahead of the weaker of data/process. Only
+  // meaningful when all three pillars have been answered.
+  const techAnswered = byPillar.technology.length > 0
+  const dataAnswered = byPillar.data.length > 0
+  const processAnswered = byPillar.process.length > 0
+  const techOverbuy =
+    techAnswered &&
+    dataAnswered &&
+    processAnswered &&
+    pillarScores.technology - Math.min(pillarScores.data, pillarScores.process) >= TECH_OVERBUY_GAP
+
+  const tier = overallScore > 0 ? (tierForScore(overallScore)?.label ?? '') : ''
+
+  return {
+    valid: answered === total,
+    answered,
+    total,
+    pillarScores,
+    overallScore,
+    level: levelForScore(overallScore),
+    tier,
+    weakestPillar,
+    nextMove: weakestPillar ? NEXT_MOVE[weakestPillar] : '',
+    techOverbuy,
+    percentile: percentileForScore(overallScore),
+  }
+}


### PR DESCRIPTION
## What

Second linkable SEO asset (after the Pipeline Coverage Calculator): a free, **no-email** RevOps maturity self-assessment.

- **16 statements** across four pillars — Process, Data, Technology, Alignment — rated 1–5
- Rolls up to an overall **maturity level** (1 Ad-hoc → 5 Optimized) + a directional **percentile** vs published B2B benchmarks (median ~2.4/5)
- Per-pillar bars, a **weakest-pillar** callout with the single highest-ROI next move, and a flag for the **"buying tools you can't feed"** anti-pattern (tech maturity outrunning data/process)

## Why

Every competitor's RevOps maturity assessment is gated behind a lead form. Ungating it removes friction, earns the link, and avoids inflated/dishonest benchmarks. Runs entirely client-side; result is instant.

## Files

| File | Role |
|---|---|
| `src/lib/revops-maturity.ts` | Pure, deterministic scoring core (no `Date`/`Math.random`) |
| `src/lib/__tests__/revops-maturity.test.ts` | 23 battle-tests: NaN/Infinity/out-of-range/partial-answer adversarial inputs + band boundaries |
| `src/app/tools/revops-maturity-scorecard/page.tsx` | Static SEO page — FAQ + breadcrumb JSON-LD, explainer, self-canonical |
| `.../_components/revops-maturity-scorecard.tsx` | Client widget (radiogroups, live results, per-pillar bars) |
| `src/components/layout/footer.tsx` | Internal link under Revenue Operations |
| `src/app/sitemap.ts` | Sitemap entry (priority 0.8) |

## SEO

- Self-canonicalizes (`/tools/revops-maturity-scorecard`) — no cascade footgun
- FAQ + BreadcrumbList JSON-LD; targets `revops maturity model` / `revenue operations maturity assessment`
- Cross-links the Pipeline Coverage Calculator, the RevOps strategy guide, and the forecast-variance case study (all GSC-confirmed-live)

## Gate

typecheck ✓ · biome ✓ · 1083 tests (+23) ✓ · build ✓

[hudsor01]