### PR TITLE
chore: final quality + dedup sweep (bug fix + residue + de-duplication)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,8 +105,8 @@ Seed (`drizzle/seed.ts`): upsert-based, idempotent. Seeds 1 author, categories, 
 | `/api/security/metrics` | GET | — | — | `METRICS_API_TOKEN` (header `X-Metrics-Token`) | Exports rate-limiter metrics |
 
 Rate limiter (`src/lib/rate-limiter/store.ts`): in-memory `Map` singleton, LRU eviction every 5 min, exponential progressive penalty with 2× multiplier. Two preset surfaces:
-- `RateLimitPresets` (`src/lib/api-rate-limit.ts:32`): `read` (100/min, burst 120/5s), `write` (30/hr, 15-min block), `sensitive` (10/hr, 30-min block).
-- `RateLimitConfigs` (`src/lib/rate-limiter/configs.ts:6`): `contactForm`, `api`, `auth`, `upload`.
+- `RateLimitPresets` (`src/lib/api-rate-limit.ts`): `read` (100/min, burst 120/5s), `sensitive` (10/hr, 30-min block).
+- `RateLimitConfigs` (`src/lib/rate-limiter/configs.ts`): `contactForm`.
 
 Use `checkRateLimitOrRespond(request, preset, path, method)` → returns a `NextResponse` (429) to short-circuit, or `null` to proceed.
 

--- a/src/app/api/blog/__tests__/route.test.ts
+++ b/src/app/api/blog/__tests__/route.test.ts
@@ -184,6 +184,17 @@ describe('GET /api/blog', () => {
     expect(body.success).toBe(false)
     expect(JSON.stringify(body)).not.toContain('/var/lib/postgres')
   })
+
+  it('rejects an invalid status query param with 400 (not a 500 from the enum query)', async () => {
+    const res = await GET(reqGet('?status=BOGUS'))
+    expect(res.status).toBe(400)
+    expect(dbMocks.findMany).not.toHaveBeenCalled()
+  })
+
+  it('accepts a valid PostStatus query param', async () => {
+    const res = await GET(reqGet('?status=PUBLISHED'))
+    expect(res.status).toBe(200)
+  })
 })
 
 describe('POST /api/blog', () => {

--- a/src/app/api/blog/route.ts
+++ b/src/app/api/blog/route.ts
@@ -21,7 +21,7 @@ import {
   createErrorResponse,
   generateSlug,
 } from '@/lib/api-blog'
-import { createBlogPostSchema } from '@/lib/schemas'
+import { createBlogPostSchema, PostStatusSchema } from '@/lib/schemas'
 import { SITE_ORIGIN, canonicalUrl } from '@/lib/absolute-url'
 
 // POST/PUT contract asymmetry (kept here so a future admin client knows
@@ -64,8 +64,23 @@ export async function GET(request: NextRequest) {
     const filters: BlogPostFilters = {}
     const isAdmin = isAdminRequest(request)
 
-    if (searchParams.get('status')) {
-      filters.status = searchParams.get('status')!
+    const statusParam = searchParams.get('status')
+    if (statusParam) {
+      // Validate against the PostStatus enum before it reaches the Drizzle
+      // inArray() clause. An invalid value would otherwise be cast straight into
+      // the Postgres enum column and rejected at query time → a 500, when the
+      // correct response to bad client input is a 400. Supports comma-separated
+      // multi-status to match buildBlogWhereClause's array handling.
+      const candidates = statusParam.split(',')
+      if (candidates.some((s) => !PostStatusSchema.safeParse(s).success)) {
+        return NextResponse.json(
+          createErrorResponse(
+            'Invalid status; must be one of DRAFT, REVIEW, SCHEDULED, PUBLISHED, ARCHIVED, DELETED'
+          ),
+          { status: 400 }
+        )
+      }
+      filters.status = candidates
     }
     if (searchParams.get('authorId')) {
       filters.authorId = searchParams.get('authorId')!
@@ -315,9 +330,6 @@ export async function POST(request: NextRequest) {
           })
       }
     }
-    // Note: the contact-form removed `Pre-existing POST/PUT contract
-    // doc-comment now lives at the top of this file` covers default
-    // semantics already.
 
     const response: ApiResponse<BlogPostData> = {
       data: transformToBlogPostData(newPost),

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -41,13 +41,6 @@ label[for],
 }
 
 @layer utilities {
-  @keyframes fadeInUp {
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-
   @keyframes shimmer {
     0% {
       background-position: -200% 0;
@@ -233,29 +226,7 @@ label[for],
 
 /* ============================================
    Luxury Minimalist Animation System
-   (consolidated from src/styles/animations.css)
    ============================================ */
-
-@keyframes subtleScale {
-  from {
-    transform: scale(0.98);
-    opacity: 0;
-  }
-  to {
-    transform: scale(1);
-    opacity: 1;
-  }
-}
-
-
-.animate-fade-in-up {
-  opacity: 0;
-  animation: fadeInUp var(--motion-duration-normal) cubic-bezier(0.16, 1, 0.3, 1) forwards;
-}
-
-.animate-scale-in {
-  animation: subtleScale 0.4s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-}
 
 .animate-pulse {
   animation: pulse 2s ease-in-out infinite;
@@ -291,7 +262,6 @@ label[for],
 
 /* ============================================
    Responsive Design Utilities and Mobile-First Patterns
-   (consolidated from src/styles/responsive-utilities.css)
    ============================================ */
 
 /* aspect-square / aspect-video mirror Tailwind v4's native utilities and are

--- a/src/app/projects/cac-unit-economics/_components/OverviewTab.tsx
+++ b/src/app/projects/cac-unit-economics/_components/OverviewTab.tsx
@@ -1,16 +1,9 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { ChartLoadError } from '@/components/charts/chart-load-error'
 import { safeLazy } from '@/lib/safe-lazy'
 import { ChartContainer } from '@/components/ui/chart-container'
-
-function ChartLoadError() {
-  return (
-    <div className="h-[var(--chart-height-sm)] w-full flex items-center justify-center bg-destructive/10 rounded-lg border border-destructive/20">
-      <p className="text-destructive text-sm">Failed to load chart</p>
-    </div>
-  )
-}
 
 const CACBreakdownChart = dynamic(
   safeLazy(() => import('./CACBreakdownChart'), 'CACBreakdownChart', ChartLoadError),

--- a/src/app/projects/customer-lifetime-value/_components/OverviewTab.tsx
+++ b/src/app/projects/customer-lifetime-value/_components/OverviewTab.tsx
@@ -1,15 +1,8 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { ChartLoadError } from '@/components/charts/chart-load-error'
 import { safeLazy } from '@/lib/safe-lazy'
-
-function ChartLoadError() {
-  return (
-    <div className="h-[var(--chart-height-sm)] w-full flex items-center justify-center bg-destructive/10 rounded-lg border border-destructive/20">
-      <p className="text-destructive text-sm">Failed to load chart</p>
-    </div>
-  )
-}
 
 const CLVPredictionChart = dynamic(
   safeLazy(() => import('./CLVPredictionChart'), 'CLVPredictionChart', ChartLoadError),

--- a/src/app/projects/customer-lifetime-value/_components/SegmentsTab.tsx
+++ b/src/app/projects/customer-lifetime-value/_components/SegmentsTab.tsx
@@ -1,18 +1,11 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { ChartLoadError } from '@/components/charts/chart-load-error'
 import { safeLazy } from '@/lib/safe-lazy'
 
 import { customerSegments } from '../data/constants'
 import { formatCurrency, formatPercent } from '../utils'
-
-function ChartLoadError() {
-  return (
-    <div className="h-[var(--chart-height-sm)] w-full flex items-center justify-center bg-destructive/10 rounded-lg border border-destructive/20">
-      <p className="text-destructive text-sm">Failed to load chart</p>
-    </div>
-  )
-}
 
 const CustomerSegmentChart = dynamic(
   safeLazy(() => import('./CustomerSegmentChart'), 'CustomerSegmentChart', ChartLoadError),

--- a/src/app/projects/deal-funnel/_components/FunnelChart.tsx
+++ b/src/app/projects/deal-funnel/_components/FunnelChart.tsx
@@ -7,7 +7,11 @@ import { safeLazy } from '@/lib/safe-lazy'
 import type { FunnelStage } from '../data/constants'
 
 const DealStageFunnelChart = dynamic(
-  safeLazy(() => import('./DealStageFunnelChart'), 'DealStageFunnelChart', ChartLoadError),
+  safeLazy(
+    () => import('./DealStageFunnelChart'),
+    'DealStageFunnelChart',
+    () => <ChartLoadError height="md" />
+  ),
   {
     loading: () => (
       <div className="h-[var(--chart-height-md)] w-full animate-pulse bg-muted rounded-lg" />

--- a/src/app/projects/deal-funnel/_components/FunnelChart.tsx
+++ b/src/app/projects/deal-funnel/_components/FunnelChart.tsx
@@ -1,17 +1,10 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { ChartLoadError } from '@/components/charts/chart-load-error'
 import { safeLazy } from '@/lib/safe-lazy'
 
 import type { FunnelStage } from '../data/constants'
-
-function ChartLoadError() {
-  return (
-    <div className="h-[var(--chart-height-md)] w-full flex items-center justify-center bg-destructive/10 rounded-lg border border-destructive/20">
-      <p className="text-destructive text-sm">Failed to load chart</p>
-    </div>
-  )
-}
 
 const DealStageFunnelChart = dynamic(
   safeLazy(() => import('./DealStageFunnelChart'), 'DealStageFunnelChart', ChartLoadError),

--- a/src/app/projects/lead-attribution/_components/ChartsGrid.tsx
+++ b/src/app/projects/lead-attribution/_components/ChartsGrid.tsx
@@ -6,7 +6,11 @@ import dynamic from 'next/dynamic'
 import { safeLazy } from '@/lib/safe-lazy'
 
 const LeadSourcePieChart = dynamic(
-  safeLazy(() => import('./LeadSourcePieChart'), 'LeadSourcePieChart', ChartLoadError),
+  safeLazy(
+    () => import('./LeadSourcePieChart'),
+    'LeadSourcePieChart',
+    () => <ChartLoadError height="md" />
+  ),
   {
     loading: () => (
       <div className="h-[var(--chart-height-md)] w-full animate-pulse bg-muted rounded-lg" />

--- a/src/app/projects/lead-attribution/_components/ChartsGrid.tsx
+++ b/src/app/projects/lead-attribution/_components/ChartsGrid.tsx
@@ -1,16 +1,9 @@
 'use client'
 
 import type { ComponentType, SVGProps } from 'react'
+import { ChartLoadError } from '@/components/charts/chart-load-error'
 import dynamic from 'next/dynamic'
 import { safeLazy } from '@/lib/safe-lazy'
-
-function ChartLoadError() {
-  return (
-    <div className="h-[var(--chart-height-md)] w-full flex items-center justify-center bg-destructive/10 rounded-lg border border-destructive/20">
-      <p className="text-destructive text-sm">Failed to load chart</p>
-    </div>
-  )
-}
 
 const LeadSourcePieChart = dynamic(
   safeLazy(() => import('./LeadSourcePieChart'), 'LeadSourcePieChart', ChartLoadError),

--- a/src/app/projects/revenue-operations-center/_components/ForecastingTab.tsx
+++ b/src/app/projects/revenue-operations-center/_components/ForecastingTab.tsx
@@ -1,15 +1,8 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { ChartLoadError } from '@/components/charts/chart-load-error'
 import { safeLazy } from '@/lib/safe-lazy'
-
-function ChartLoadError() {
-  return (
-    <div className="h-[var(--chart-height-md)] w-full flex items-center justify-center bg-destructive/10 rounded-lg border border-destructive/20">
-      <p className="text-destructive text-sm">Failed to load chart</p>
-    </div>
-  )
-}
 
 const ForecastAccuracyChart = dynamic(
   safeLazy(() => import('./ForecastAccuracyChart'), 'ForecastAccuracyChart', ChartLoadError),

--- a/src/app/projects/revenue-operations-center/_components/ForecastingTab.tsx
+++ b/src/app/projects/revenue-operations-center/_components/ForecastingTab.tsx
@@ -5,7 +5,11 @@ import { ChartLoadError } from '@/components/charts/chart-load-error'
 import { safeLazy } from '@/lib/safe-lazy'
 
 const ForecastAccuracyChart = dynamic(
-  safeLazy(() => import('./ForecastAccuracyChart'), 'ForecastAccuracyChart', ChartLoadError),
+  safeLazy(
+    () => import('./ForecastAccuracyChart'),
+    'ForecastAccuracyChart',
+    () => <ChartLoadError height="md" />
+  ),
   {
     loading: () => (
       <div className="h-[var(--chart-height-md)] w-full animate-pulse bg-muted rounded-lg" />

--- a/src/app/projects/revenue-operations-center/_components/OverviewTab.tsx
+++ b/src/app/projects/revenue-operations-center/_components/OverviewTab.tsx
@@ -5,7 +5,11 @@ import { ChartLoadError } from '@/components/charts/chart-load-error'
 import { safeLazy } from '@/lib/safe-lazy'
 
 const RevenueOverviewChart = dynamic(
-  safeLazy(() => import('./RevenueOverviewChart'), 'RevenueOverviewChart', ChartLoadError),
+  safeLazy(
+    () => import('./RevenueOverviewChart'),
+    'RevenueOverviewChart',
+    () => <ChartLoadError height="md" />
+  ),
   {
     loading: () => (
       <div className="h-[var(--chart-height-md)] w-full animate-pulse bg-muted rounded-lg" />
@@ -15,7 +19,11 @@ const RevenueOverviewChart = dynamic(
 )
 
 const OperationalMetricsChart = dynamic(
-  safeLazy(() => import('./OperationalMetricsChart'), 'OperationalMetricsChart', ChartLoadError),
+  safeLazy(
+    () => import('./OperationalMetricsChart'),
+    'OperationalMetricsChart',
+    () => <ChartLoadError height="md" />
+  ),
   {
     loading: () => (
       <div className="h-[var(--chart-height-md)] w-full animate-pulse bg-muted rounded-lg" />

--- a/src/app/projects/revenue-operations-center/_components/OverviewTab.tsx
+++ b/src/app/projects/revenue-operations-center/_components/OverviewTab.tsx
@@ -1,15 +1,8 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { ChartLoadError } from '@/components/charts/chart-load-error'
 import { safeLazy } from '@/lib/safe-lazy'
-
-function ChartLoadError() {
-  return (
-    <div className="h-[var(--chart-height-md)] w-full flex items-center justify-center bg-destructive/10 rounded-lg border border-destructive/20">
-      <p className="text-destructive text-sm">Failed to load chart</p>
-    </div>
-  )
-}
 
 const RevenueOverviewChart = dynamic(
   safeLazy(() => import('./RevenueOverviewChart'), 'RevenueOverviewChart', ChartLoadError),

--- a/src/app/projects/revenue-operations-center/_components/PipelineTab.tsx
+++ b/src/app/projects/revenue-operations-center/_components/PipelineTab.tsx
@@ -1,15 +1,8 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { ChartLoadError } from '@/components/charts/chart-load-error'
 import { safeLazy } from '@/lib/safe-lazy'
-
-function ChartLoadError() {
-  return (
-    <div className="h-[var(--chart-height-md)] w-full flex items-center justify-center bg-destructive/10 rounded-lg border border-destructive/20">
-      <p className="text-destructive text-sm">Failed to load chart</p>
-    </div>
-  )
-}
 
 const PipelineHealthChart = dynamic(
   safeLazy(() => import('./PipelineHealthChart'), 'PipelineHealthChart', ChartLoadError),

--- a/src/app/projects/revenue-operations-center/_components/PipelineTab.tsx
+++ b/src/app/projects/revenue-operations-center/_components/PipelineTab.tsx
@@ -5,7 +5,11 @@ import { ChartLoadError } from '@/components/charts/chart-load-error'
 import { safeLazy } from '@/lib/safe-lazy'
 
 const PipelineHealthChart = dynamic(
-  safeLazy(() => import('./PipelineHealthChart'), 'PipelineHealthChart', ChartLoadError),
+  safeLazy(
+    () => import('./PipelineHealthChart'),
+    'PipelineHealthChart',
+    () => <ChartLoadError height="md" />
+  ),
   {
     loading: () => (
       <div className="h-[var(--chart-height-md)] w-full animate-pulse bg-muted rounded-lg" />

--- a/src/components/charts/chart-load-error.tsx
+++ b/src/components/charts/chart-load-error.tsx
@@ -1,15 +1,16 @@
 /**
  * Shared ErrorBoundary fallback for lazily-loaded project charts.
- * (Previously copy-pasted verbatim into 8 project _components files.)
+ * Previously copy-pasted into 8 project _components files as two variants that
+ * differed only in chart height. Markup is preserved verbatim from those copies.
  */
 export function ChartLoadError({ height = 'sm' }: { height?: 'sm' | 'md' }) {
   return (
     <div
-      className={`flex items-center justify-center rounded-lg border border-border bg-muted/30 ${
+      className={`${
         height === 'md' ? 'h-[var(--chart-height-md)]' : 'h-[var(--chart-height-sm)]'
-      }`}
+      } w-full flex items-center justify-center bg-destructive/10 rounded-lg border border-destructive/20`}
     >
-      <p className="text-sm text-muted-foreground">Unable to load chart</p>
+      <p className="text-destructive text-sm">Failed to load chart</p>
     </div>
   )
 }

--- a/src/components/charts/chart-load-error.tsx
+++ b/src/components/charts/chart-load-error.tsx
@@ -1,0 +1,15 @@
+/**
+ * Shared ErrorBoundary fallback for lazily-loaded project charts.
+ * (Previously copy-pasted verbatim into 8 project _components files.)
+ */
+export function ChartLoadError({ height = 'sm' }: { height?: 'sm' | 'md' }) {
+  return (
+    <div
+      className={`flex items-center justify-center rounded-lg border border-border bg-muted/30 ${
+        height === 'md' ? 'h-[var(--chart-height-md)]' : 'h-[var(--chart-height-sm)]'
+      }`}
+    >
+      <p className="text-sm text-muted-foreground">Unable to load chart</p>
+    </div>
+  )
+}

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -4,9 +4,7 @@ import { z } from 'zod'
 import {
   cn,
   truncate,
-  formatRelativeTime,
   generateId,
-  slugify,
   parseParam,
   safeJsonParse,
   escapeRegExp,
@@ -47,17 +45,6 @@ describe('truncate', () => {
   })
 })
 
-describe('formatRelativeTime', () => {
-  it('returns a string for a recent date', () => {
-    const recent = new Date(Date.now() - 5_000).toISOString()
-    expect(typeof formatRelativeTime(recent)).toBe('string')
-  })
-
-  it('accepts Date objects', () => {
-    expect(typeof formatRelativeTime(new Date())).toBe('string')
-  })
-})
-
 describe('generateId', () => {
   it('returns a string of the requested length', () => {
     expect(generateId(8).length).toBe(8)
@@ -66,24 +53,6 @@ describe('generateId', () => {
 
   it('uses base-36 charset only', () => {
     expect(generateId(20)).toMatch(/^[0-9a-z]+$/)
-  })
-})
-
-describe('slugify', () => {
-  it('lowercases and replaces spaces with dashes', () => {
-    expect(slugify('Hello World')).toBe('hello-world')
-  })
-
-  it('replaces & with -and-', () => {
-    expect(slugify('cats & dogs')).toBe('cats-and-dogs')
-  })
-
-  it('strips special characters', () => {
-    expect(slugify('Hello! @World#')).toBe('hello-world')
-  })
-
-  it('collapses multiple dashes', () => {
-    expect(slugify('a---b')).toBe('a-b')
   })
 })
 

--- a/src/lib/absolute-url.ts
+++ b/src/lib/absolute-url.ts
@@ -18,10 +18,10 @@ export const SITE_ORIGIN = 'https://richardwhudsonjr.com'
  * Coerce a value into an absolute URL rooted at `SITE_ORIGIN`. Idempotent:
  * already-absolute `http://` or `https://` URLs pass through unchanged.
  *
- * Named `canonicalUrl` (not `absoluteUrl`) to avoid colliding with the
- * env-aware `absoluteUrl()` in `src/lib/utils.ts`, which exists for
- * client-side link building and uses `window.location.origin` /
- * `NEXT_PUBLIC_SITE_URL`. This one is pinned to prod by design.
+ * Named `canonicalUrl` to distinguish it from the env-aware
+ * `absoluteUrlTestable()` in `src/lib/utils.ts`, which builds client-side
+ * links from `window.location.origin` / `NEXT_PUBLIC_SITE_URL`. This one is
+ * pinned to prod (`SITE_ORIGIN`) by design.
  *
  * Use this anywhere a value of mixed provenance (DB field, function
  * argument) is rendered into JSON-LD, OG `url`, sitemap `<loc>`, or

--- a/src/lib/api-request.ts
+++ b/src/lib/api-request.ts
@@ -1,6 +1,6 @@
 /**
  * API Request Utilities — Canonical request parsing
- * Single source of truth for getClientIdentifier, getRequestMetadata, parseRequestBody.
+ * Single source of truth for getClientIdentifier / getClientIdentifierFromHeaders.
  */
 
 import type { NextRequest } from 'next/server'
@@ -40,7 +40,7 @@ export function getClientIdentifierFromHeaders(headers: HeaderGetter): string {
 
 /**
  * Extract client identifier from a Request-like object for rate limiting.
- * Canonical implementation — replaces all duplicates in api-utils.ts and rate-limiter/helpers.ts.
+ * Canonical implementation — the single source of truth for client identification.
  */
 export function getClientIdentifier(request: NextRequest | Request): string {
   return getClientIdentifierFromHeaders(request.headers)

--- a/src/lib/charts.ts
+++ b/src/lib/charts.ts
@@ -1,6 +1,6 @@
 /**
  * Comprehensive Chart System
- * Consolidates chart colors, themes, utilities, and validators
+ * Consolidates chart colors, themes, styles, and value formatters
  */
 
 import { CHART_FORMAT_TYPES } from '@/types/chart'

--- a/src/lib/email-service.ts
+++ b/src/lib/email-service.ts
@@ -89,9 +89,15 @@ export class EmailService {
       })
 
       if (contactResult.error) {
+        // Resend's error is an object ({ message, name, statusCode }); String()
+        // would stringify it to "[object Object]" and lose the reason. Keep the
+        // human-readable message on the Error and the full object as context.
         logger.error(
           'Failed to send contact notification',
-          new Error(String(contactResult.error) || 'Unknown error')
+          new Error(contactResult.error.message),
+          {
+            resendError: contactResult.error,
+          }
         )
         return {
           success: false,
@@ -111,7 +117,7 @@ export class EmailService {
 
         // Auto-reply failure is not critical
         if (autoReplyResult.error) {
-          emailLogger.warn('Failed to send auto-reply', { error: String(autoReplyResult.error) })
+          emailLogger.warn('Failed to send auto-reply', { resendError: autoReplyResult.error })
         } else {
           autoReplyEmailId = autoReplyResult.data?.id
         }

--- a/src/lib/sanitization.ts
+++ b/src/lib/sanitization.ts
@@ -33,20 +33,6 @@ export function stripCrlf(value: string): string {
   return value.replace(/[\r\n]+/g, ' ')
 }
 
-/**
- * Client-Safe HTML Sanitization
- * Used in Client Components to avoid Vercel serverless costs
- * For use in Client Components only - do NOT import in Server Components.
- *
- * Uses plain `dompurify` (not `isomorphic-dompurify`). Plain dompurify's
- * module-load is side-effect-free; the factory only touches `window` when
- * `.sanitize()` is called. `isomorphic-dompurify` pulled `jsdom` into the
- * server bundle and 500'd every /blog/[slug] render under Next.js 16 /
- * Turbopack because jsdom's runtime `data/patch.json` lookup fails.
- * Calling sanitizeBlogHtml/stripHtml on the server will throw — by
- * contract they are client-only.
- */
-
 // Whitespace strip used before scheme parsing. Byte-identical to DOMPurify's
 // ATTR_WHITESPACE (github.com/cure53/DOMPurify/blob/main/src/regexp.ts) and
 // a strict superset of the WHATWG URL parser's strip set

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -28,38 +28,8 @@ export function truncate(text: string, maxLength: number): string {
   return text.length <= maxLength ? text : `${text.substring(0, maxLength)}...`
 }
 
-export function formatRelativeTime(date: string | Date): string {
-  const dateObj = typeof date === 'string' ? new Date(date) : date
-  const now = new Date()
-  const diffInSeconds = Math.floor((now.getTime() - dateObj.getTime()) / 1000)
-
-  const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' })
-
-  if (diffInSeconds < 60) return rtf.format(-diffInSeconds, 'second')
-  const diffInMinutes = Math.floor(diffInSeconds / 60)
-  if (diffInMinutes < 60) return rtf.format(-diffInMinutes, 'minute')
-  const diffInHours = Math.floor(diffInMinutes / 60)
-  if (diffInHours < 24) return rtf.format(-diffInHours, 'hour')
-  const diffInDays = Math.floor(diffInHours / 24)
-  if (diffInDays < 30) return rtf.format(-diffInDays, 'day')
-  const diffInMonths = Math.floor(diffInDays / 30)
-  if (diffInMonths < 12) return rtf.format(-diffInMonths, 'month')
-  return rtf.format(-Math.floor(diffInMonths / 12), 'year')
-}
-
 export function generateId(length = 8): string {
   return Array.from({ length }, () => Math.floor(Math.random() * 36).toString(36)).join('')
-}
-
-export function slugify(text: string): string {
-  return text
-    .toString()
-    .toLowerCase()
-    .trim()
-    .replace(/\s+/g, '-')
-    .replace(/&/g, '-and-')
-    .replace(/[^\w-]+/g, '')
-    .replace(/--+/g, '-')
 }
 
 export function parseParam<T>(value: string | string[] | undefined, defaultValue: T): T {

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -30,12 +30,6 @@ export enum ContentType {
 // UTILITY TYPES — Drizzle relational shapes
 // ============================================================================
 
-export type BlogPostWithRelations = BlogPost & {
-  author: Author | null
-  category: Category | null
-  tags: Array<{ tag: Tag }>
-}
-
 export type CategoryWithPosts = Category & {
   posts: BlogPost[]
   children: Category[]


### PR DESCRIPTION
Acts on the verified final quality+dedup audit (39 confirmed findings, adversarially verified + independently spot-checked). Landing in batches.

## Batch A — correctness + error-handling + residue + CSS dedup
- **Bug:** `/api/blog` GET validates `status` against `PostStatusSchema` before the Drizzle enum `inArray` — `?status=BOGUS` now returns **400** instead of a 500 (Postgres enum rejection). +2 regression tests.
- **Error handling:** `email-service` stops `String()`-coercing Resend's error object (was logging `"[object Object]"`, losing the reason); keeps message + structured context.
- **Residue:** fixed 7 stale doc-comments referencing deleted symbols (api-request, charts, sanitization, absolute-url, globals.css provenance, blog-route garbled comment) + CLAUDE.md rate-limiter presets.
- **CSS dedup:** `.animate-fade-in-up` / `.animate-scale-in` were each defined twice — removed the shadowed copies + orphaned `@keyframes fadeInUp`/`subtleScale` (zero visual change).

## Batch B — lib/type dedup
- `utils.ts`: removed `formatRelativeTime` (dup of `data-formatters.formatRelativeDate`) + `slugify` (dead dup) + their tests.
- `types/blog.ts`: removed the byte-identical `BlogPostWithRelations` (the consumed copy lives in `api-blog.ts`).

More dedup batches to follow on this branch.

## Gate
typecheck ✓ · 954 tests ✓ · build ✓

[hudsor01]