### PR TITLE
perf: fix the real performance-audit findings (low-severity)

### DIFF
--- a/src/app/api/blog/route.ts
+++ b/src/app/api/blog/route.ts
@@ -314,6 +314,10 @@ export async function POST(request: NextRequest) {
             keyLocation: canonicalUrl(`/${indexNowKey}.txt`),
             urlList: [postUrl],
           }),
+          // Bound the un-awaited ping: a slow/hung IndexNow endpoint must not
+          // keep the serverless instance alive past the already-sent 201.
+          // Abort surfaces as an AbortError in the .catch below.
+          signal: AbortSignal.timeout(3000),
         })
           .then((res) => {
             if (!res.ok) {

--- a/src/components/blog/related-posts-utils.ts
+++ b/src/components/blog/related-posts-utils.ts
@@ -18,10 +18,11 @@ export function selectRelatedPosts<T extends RelatedPostInput>(
   limit: number
 ): T[] {
   const others = all.filter((p) => p.slug !== current.slug)
+  const currentTags = new Set(current.tags)
   const tagged = others
     .map((p) => ({
       post: p,
-      overlap: p.tags.filter((t) => current.tags.includes(t)).length,
+      overlap: p.tags.filter((t) => currentTags.has(t)).length,
     }))
     .filter((x) => x.overlap > 0)
     .sort((a, b) => {

--- a/src/components/ui/field.tsx
+++ b/src/components/ui/field.tsx
@@ -199,7 +199,9 @@ function FieldError({
 
     return (
       <ul className="ml-4 flex list-disc flex-col gap-1">
-        {uniqueErrors.map((error, index) => error?.message && <li key={index}>{error.message}</li>)}
+        {uniqueErrors.map(
+          (error, index) => error?.message && <li key={error?.message ?? index}>{error.message}</li>
+        )}
       </ul>
     )
   }, [children, errors])

--- a/src/lib/data-service/cache.ts
+++ b/src/lib/data-service/cache.ts
@@ -30,7 +30,11 @@ export class DataCacheService {
       ttl,
     })
 
-    logger.debug('Data cached', { key, ttl, size: JSON.stringify(data).length })
+    // No `size: JSON.stringify(data).length` — the arg is evaluated eagerly on
+    // every set, even in prod where the debug log is discarded (LOG_LEVEL=info),
+    // forcing a full serialization of potentially-large analytics payloads per
+    // write for telemetry that never ships.
+    logger.debug('Data cached', { key, ttl })
     this.enforceSizeLimit()
   }
 

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -19,21 +19,27 @@ export function markdownToHtml(markdown: string): string {
   return externalizeLinks(demoteHeadings(html))
 }
 
+// Heading-demotion passes, ordered high→low so a heading demoted on one pass
+// isn't demoted again. Compiled once at module load rather than rebuilding 10
+// RegExp objects on every render. Global regexes are safe to reuse across
+// calls: String.prototype.replace resets lastIndex when it completes.
+const HEADING_DEMOTIONS = [5, 4, 3, 2, 1].map((level) => ({
+  openTag: new RegExp(`<h${level}(\\s[^>]*)?>`, 'gi'),
+  closeTag: new RegExp(`</h${level}>`, 'gi'),
+  openReplacement: `<h${level + 1}$1>`,
+  closeReplacement: `</h${level + 1}>`,
+}))
+
 /**
  * Shift every heading down one level (h1→h2 … h5→h6; h6 unchanged) so body
  * markdown never emits an `<h1>` that competes with the page title's `<h1>`.
  * A double-h1 confuses Google's content-hierarchy parser; this preserves the
  * visual hierarchy (the `prose` wrapper styles h2–h6) while fixing semantics.
- *
- * Processed high→low so a heading demoted on one pass isn't demoted again.
  */
 function demoteHeadings(html: string): string {
   let out = html
-  for (let level = 5; level >= 1; level--) {
-    const next = level + 1
-    out = out
-      .replace(new RegExp(`<h${level}(\\s[^>]*)?>`, 'gi'), `<h${next}$1>`)
-      .replace(new RegExp(`</h${level}>`, 'gi'), `</h${next}>`)
+  for (const { openTag, closeTag, openReplacement, closeReplacement } of HEADING_DEMOTIONS) {
+    out = out.replace(openTag, openReplacement).replace(closeTag, closeReplacement)
   }
   return out
 }

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -175,17 +175,19 @@ export function highlightSearchTerms(text: string, query: string): string {
     .split(/\s+/)
     .filter((term) => term.length > 2)
 
-  let highlighted = text
-
-  for (const term of terms) {
-    // Escape regex metacharacters — terms come from user query strings, so
-    // an unescaped `(`, `[`, `\`, `?`, etc. would throw SyntaxError and
-    // bubble up through highlightSearchTerms callers.
-    const regex = new RegExp(`(${escapeRegExp(term)})`, 'gi')
-    highlighted = highlighted.replace(regex, '<mark>$1</mark>')
+  // No terms survive the length filter → nothing to mark. Guard before building
+  // the regex: an empty alternation (`()`) would match the empty string at every
+  // position and wrap the whole text in <mark>.
+  if (terms.length === 0) {
+    return text
   }
 
-  return highlighted
+  // Single alternation over all terms — one compile + one pass instead of
+  // recompiling a regex and re-scanning the text per term. Each term is regex-
+  // escaped: terms come from user query strings, so an unescaped `(`, `[`, `\`,
+  // `?`, etc. would throw SyntaxError and bubble up through callers.
+  const regex = new RegExp(`(${terms.map(escapeRegExp).join('|')})`, 'gi')
+  return text.replace(regex, '<mark>$1</mark>')
 }
 
 export async function getSearchSuggestions(prefix: string, limit: number = 5): Promise<string[]> {


### PR DESCRIPTION
## Summary

A performance audit flagged **12 critical / 8 high / 14 medium / 9 low** issues. I verified every claim against source. **Almost none of the critical/high items were real** — they were misreads of guarded or dependent code, a false premise about the DB driver, or would actively regress behavior. This PR fixes the **6 findings that actually hold up**. All are genuinely real but low-impact; included regardless of severity per request.

### Fixes
| File | Fix |
|---|---|
| `lib/data-service/cache.ts` | Drop `size: JSON.stringify(data).length` from the debug log — eagerly evaluated on every `set` even in prod where the debug line is discarded, forcing a full serialization of large analytics payloads for telemetry that never ships. |
| `app/api/blog/route.ts` | Add `AbortSignal.timeout(3000)` to the fire-and-forget IndexNow ping so a slow/hung endpoint can't keep the serverless instance alive past the already-sent 201. |
| `components/ui/field.tsx` | Key error `<li>`s by their (already-deduped) message instead of array index. |
| `components/blog/related-posts-utils.ts` | Hoist `current.tags` into a `Set` for the tag-overlap check instead of `Array.includes` per candidate tag. |
| `lib/markdown.ts` | Compile the 10 heading-demotion regexes once at module load instead of rebuilding them per render (safe to reuse — `replace` resets a global regex's `lastIndex`). |
| `lib/search.ts` | Collapse `highlightSearchTerms`' per-term regex loop into one alternation pass, with an empty-terms guard so a ≤2-char query still returns text unchanged. |

### Audit claims rejected (not fixed, with reason)
- **CRITICAL: sitemap `force-dynamic` → switch to ISR** — would reintroduce a documented SEO regression (build-phase prerender skips the DB branch); intent is explained in `sitemap.ts:9-19`. Sitemap is bot-traffic only.
- **CRITICAL: view-count increment "leaks connections"** — false premise; the project uses the stateless **neon-http** driver (no connection pool to exhaust).
- **HIGH: `searchBlogPosts` "5 sequential queries, parallelize"** — common path is 1 query (early return); the fuzzy query depends on full-text IDs and pg_trgm/ILIKE are mutually exclusive branches.
- **HIGH: `enforceSizeLimit` "sorts on every write"** — guarded by a `size <= 500` early return; only sorts when over capacity, then batch-evicts.
- **HIGH: POST blog "parallelize awaits"** — the read-back reads the `tags` relation, so it must run after the `postTags` insert.
- **MEDIUM ×3: scroll/resize listeners "no cleanup → memory leak"** — all three already return `removeEventListener` cleanups.
- **MEDIUM: RSS "N+1"** — Drizzle relational `with` compiles to a single query; route is CDN-cached.
- Plus several negligible/self-debunked items (projects `.find()`, `getCategories` Set, rate-limiter sorts, env-validation).

## Verification
- `bun run typecheck` — clean
- `bun run lint` (Biome) — clean
- `bunx vitest run` — **943 tests pass (88 files)**

[hudsor01]